### PR TITLE
Changed parsing of email addr targets to need only one colon

### DIFF
--- a/src/Ghosts.Client/Infrastructure/Email/EmailConfiguration.cs
+++ b/src/Ghosts.Client/Infrastructure/Email/EmailConfiguration.cs
@@ -141,7 +141,7 @@ namespace Ghosts.Client.Infrastructure.Email
             {
                 var o = raw.Split(Convert.ToChar(":"));
 
-                if (o.GetUpperBound(0) > 1) //supplied list
+                if (o.GetUpperBound(0) > 0) //supplied list
                 {
                     var l = o[1];
                     var emails = l.Split(Convert.ToChar(","));


### PR DESCRIPTION

This changes the parsing of an email random list to expect only one ':' after random.
From the docs, it appears that specifying
```
 random:<addr1>,<addr2>,....<addrN>
```
should allow random picks from the address list. However, it actually needed to be as follows (note the ':' ) at the end, needed two colons in the string.
```
random:<addr1>,<addr2>,....<addrN>:
```
The change allows the first string to work, and is upward compatible with the second string.