### PR TITLE
Extend watcher for folders

### DIFF
--- a/src/Ghosts.Client/Ghosts.Client.csproj
+++ b/src/Ghosts.Client/Ghosts.Client.csproj
@@ -636,6 +636,7 @@
     <None Include="Sample Timelines\PowerPoint.json" />
     <None Include="Sample Timelines\Print.json" />
     <None Include="Sample Timelines\Reboot.json" />
+    <None Include="Sample Timelines\Ssh.json" />
     <None Include="Sample Timelines\trackables timeline.json" />
     <None Include="Sample Timelines\watcher.json" />
     <None Include="Sample Timelines\Word.json" />

--- a/src/Ghosts.Client/Handlers/Watcher.cs
+++ b/src/Ghosts.Client/Handlers/Watcher.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Windows.Forms;
+using System.Collections.Generic;
 
 namespace Ghosts.Client.Handlers
 {
@@ -45,17 +46,10 @@ namespace Ghosts.Client.Handlers
 
                 switch (timelineEvent.Command)
                 {
-                    //TODO:watch folders
-                    //case "folder":
-                    //    while (true)
-                    //    {
-                    //        var cmd = timelineEvent.CommandArgs[_random.Next(0, timelineEvent.CommandArgs.Count)];
-                    //        if (!string.IsNullOrEmpty(cmd))
-                    //        {
-                    //            this.Command(handler, timelineEvent, cmd);
-                    //        }
-                    //        Thread.Sleep(timelineEvent.DelayAfter);
-                    //    }
+                    //watch a folder, each handler watches one folder
+                    case "folder":
+                        var fw = new FolderWatcher(handler, timelineEvent, timelineEvent.Command);
+                        break;
                     //File
                     default:
                         var w = new FileWatcher(handler, timelineEvent, timelineEvent.Command);
@@ -70,7 +64,224 @@ namespace Ghosts.Client.Handlers
         }
     }
 
-    internal class FileWatcher : BaseHandler
+    internal class Afile 
+    {
+        public string name { get; set; }
+        public long size { get; set; }
+        public DateTime ctime { get; set; }
+
+        //default sort method uses only the size
+        public static int CompareBySize(Afile x, Afile y)
+        {
+            // A null value means that this object is greater.
+            if (y == null || x.size > y.size)
+                return 1;
+            else if (x.size == y.size) return 0;
+            else return -1;
+        }
+
+        public static int CompareByDate(Afile x, Afile y)
+        {
+            // A null value means that this object is greater.
+            if (y == null || x.ctime > y.ctime)
+                return 1;
+            else if (x.ctime == y.ctime) return 0;
+            else return -1;
+        }
+
+
+
+    }
+
+        internal class FolderWatcher : BaseHandler
+    {
+        private TimelineHandler _handler;
+        private TimelineEvent _timelineEvent;
+        private readonly string _command;
+        private string folderPath = null;
+        private long folderMaxSize = -1;   //in bytes
+        private long lastFolderSize = -1;  // last known size of this folder
+        private string deletionApproach = "random";
+        private FileSystemWatcher watcher;
+
+        static void GetAllFiles(string folder, List<Afile> allfiles )
+        {
+            // Get array of all file names.
+            string[] filelist = Directory.GetFiles(folder, "*");
+            foreach (string fname in filelist)
+            {
+                FileInfo info = new FileInfo(fname);
+                allfiles.Add(new Afile() { name = info.FullName, size = info.Length, ctime = info.LastWriteTime });
+            }
+            //get subdirectories
+            string[] dirlist = Directory.GetDirectories(folder, "*");
+            foreach (string dname in dirlist)
+            {
+                GetAllFiles(dname,allfiles);
+            }
+        }
+
+        //returns total directory size including sub directories
+        static long GetDirectorySize(string folder)
+        {
+            // Get array of all file names.
+            string[] filelist = Directory.GetFiles(folder, "*");
+
+            // Sum file sizes
+            long size = 0;
+            foreach (string fname in filelist)
+            {
+                FileInfo info = new FileInfo(fname);
+                size += info.Length;
+            }
+            //recurse, sum sub directory sizes
+            string [] dirlist = Directory.GetDirectories(folder, "*");
+            foreach (string dname in dirlist)
+            {
+                size += GetDirectorySize(dname);
+            }
+            // Return total size
+            return size;
+        }
+
+        internal FolderWatcher(TimelineHandler handler, TimelineEvent timelineEvent, string command)
+        {
+            _handler = handler;
+            _timelineEvent = timelineEvent;
+            _command = command;
+
+
+
+            //parse the command args
+            char[] charSeparators = new char[] { ':' };
+            foreach (var cmd in timelineEvent.CommandArgs)
+            {
+                //each argument string is key:value, parse this
+                var argString = cmd.ToString();
+                if (!string.IsNullOrEmpty(argString)) {
+                    var words = argString.Split(charSeparators, 2, StringSplitOptions.None);
+                    if (words.Length == 2)
+                    {
+                        if (words[0] == "path") folderPath = words[1];
+                        else if (words[0] == "size" && Int64.TryParse(words[1], out long localsize)) folderMaxSize = localsize * 1024 * 1024;
+                        else if (words[0] == "deletionApproach") deletionApproach = words[1];
+                    }
+                }
+            }
+
+            //validate the arguments
+            if (folderPath == null) {
+                Log.Trace("In Watcher handler, no 'path' argument specified for a folder path, Watcher exiting.");
+                return;
+            }
+            if (!Directory.Exists(folderPath))
+            {
+                Log.Trace("In Watcher handler, 'path' argument " + folderPath + " is not a valid folder, Watcher exiting.");
+                return;
+            }
+
+            if (folderMaxSize == -1)
+            {
+                Log.Trace("In Watcher handler, no 'size' argument is specified for a folder path, Watcher exiting.");
+                return;
+            }
+
+            if (!(deletionApproach == "random" || deletionApproach == "oldest" || deletionApproach == "largest"))
+            {
+                Log.Trace("In Watcher handler, 'deletionApproach' argument {deletionApproach} is unrecognized using random.");
+                deletionApproach = "random";
+            }
+
+            lastFolderSize = GetDirectorySize(folderPath);
+
+            watcher = new FileSystemWatcher(folderPath);
+            watcher.NotifyFilter = NotifyFilters.Size;
+            watcher.EnableRaisingEvents = true;
+            watcher.IncludeSubdirectories = true;
+            watcher.Changed += OnChanged;
+
+            Log.Trace($"Setting up watcher for folder {folderPath} with maxSize {folderMaxSize} (total bytes)");
+
+            // Begin watching.
+            watcher.EnableRaisingEvents = true;
+
+            //keep thread alive forever
+            Application.Run();
+        }
+
+        // Define the event handlers.
+        private void OnChanged(object source, FileSystemEventArgs e)
+        {
+            // ignore if size is shrinking
+            var currentSize = GetDirectorySize(folderPath);
+            if (currentSize > lastFolderSize && currentSize > folderMaxSize)
+            {
+                //size has grown, exceeds max, need to delete
+                //get a list of all files with their sizes
+                List<Afile> allfiles = new List<Afile>();
+                GetAllFiles(folderPath, allfiles);
+
+                while (true) {
+                    Afile targetFile = null;
+                    
+                    if (deletionApproach == "oldest")
+                    {
+                        allfiles.Sort(Afile.CompareByDate);
+                        targetFile = allfiles[0];
+                        allfiles.RemoveAt(0);
+                    }
+                    else if (deletionApproach == "largest")
+                    {
+                        allfiles.Sort(Afile.CompareBySize);
+                        targetFile = allfiles[0];
+                        allfiles.RemoveAt(0);
+                    }
+                    else
+                    {
+                        //default is random
+                        int targetIndex = _random.Next(0, allfiles.Count);
+                        targetFile = allfiles[targetIndex];
+                        allfiles.RemoveAt(targetIndex);
+                    }
+                    //now delete the file
+                    try
+                    {
+                        File.Delete(targetFile.name);
+                        //update current size
+                        currentSize = currentSize - targetFile.size;
+                        if (currentSize < folderMaxSize) break;  //break from loop, we have hit the target size
+                    }
+                    catch (Exception deletionException)
+                    {
+                        //ignore the exception, file may be protected
+                        Log.Trace($"Watcher: unable to delete {targetFile.name} to reduce folder {folderPath} size, exception {deletionException}");
+                    }
+                    if (allfiles.Count == 0)
+                    {
+                        //no more files to try to delete and loop is still running. 
+                        //disable any future execution
+                        watcher.EnableRaisingEvents = false;
+                        break; //break out of the loop
+
+                    }
+
+                }
+                
+
+
+                lastFolderSize = currentSize;
+            }
+            else
+            {
+                lastFolderSize = currentSize;
+            }
+        }
+
+
+
+    }
+
+        internal class FileWatcher : BaseHandler
     {
         private TimelineHandler _handler;
         private TimelineEvent _timelineEvent;

--- a/src/Ghosts.Client/Handlers/Watcher.cs
+++ b/src/Ghosts.Client/Handlers/Watcher.cs
@@ -145,8 +145,12 @@ namespace Ghosts.Client.Handlers
             long size = 0;
             foreach (string fname in filelist)
             {
-                FileInfo info = new FileInfo(fname);
-                size += info.Length;
+                try
+                {
+                    FileInfo info = new FileInfo(fname);
+                    size += info.Length;
+                }
+                catch { }  //ignore any errors when accessing the file
             }
             //recurse, sum sub directory sizes
             string [] dirlist = Directory.GetDirectories(folder, "*");
@@ -176,7 +180,7 @@ namespace Ghosts.Client.Handlers
                     var words = argString.Split(charSeparators, 2, StringSplitOptions.None);
                     if (words.Length == 2)
                     {
-                        if (words[0] == "path") folderPath = words[1];
+                        if (words[0] == "path") folderPath = Environment.ExpandEnvironmentVariables(words[1]);
                         else if (words[0] == "size" && Int64.TryParse(words[1], out long localsize)) folderMaxSize = localsize * 1024 * 1024;
                         else if (words[0] == "deletionApproach") deletionApproach = words[1];
                     }
@@ -280,7 +284,7 @@ namespace Ghosts.Client.Handlers
                         }
                         
                     }
-                    catch (Exception deletionException)
+                    catch 
                     {
                         //ignore the exception, file may be protected or in the process of being written
                         Log.Trace($"Watcher: unable to delete {targetFile.name} to reduce folder {folderPath} size, either in use or protected.");

--- a/src/Ghosts.Client/Sample Timelines/Ssh.json
+++ b/src/Ghosts.Client/Sample Timelines/Ssh.json
@@ -40,7 +40,7 @@
         {
           "Command": "random",
           "CommandArgs": [
-            "10.200.128.135|10.200.128.135_ncraf|ls -lah;ls -ltrh;help;pwd;date;time;uptime;uname -a;df -h;cd ~;cd [remotedirectory];touch [randomname].[randomextension];mkdir [randomname]"  //<serverIP>|<credKey|<commmandList>
+            "<an IP>|<unique_key_from_credentials>|ls -lah;ls -ltrh;help;pwd;date;time;uptime;uname -a;df -h;cd ~;cd [remotedirectory];touch [randomname].[randomextension];mkdir [randomname]"  //<serverIP>|<credKey|<commmandList>
           ],
           "DelayAfter": 20000,
           "DelayBefore": 0

--- a/src/Ghosts.Client/Sample Timelines/Watcher.json
+++ b/src/Ghosts.Client/Sample Timelines/Watcher.json
@@ -1,19 +1,53 @@
-﻿{
-    "TimeLineHandlers": [
+﻿/// The 'folder' command for Watcher is intended to monitor diskspace in a target folder
+/// The CommandArgs are in key:value pairs
+///   path:<some folder>  - folder to watch
+///   size:<max size in MB> - maximum folder size in MB
+///   deletionApproach:oldest|largest|random
+///
+/// If max size is exceeded, then files are deleted from the folder using the deletionApproach
+/// until the folder size is under max size.
+/// One obvious use of this is to monitor the browser downloads directory, i.e.
+/// path:%HOMEDRIVE%%HOMEPATH%\\Downloads
+/// The deletion action can result in deleting a file that is in the progress of being downloaded
+/// which results in a failed download by the browser for this file. But since the goal is
+/// traffic generation, this is not a deal breaker.  
+///
+
+
+
+
+
+{
+  "TimeLineHandlers": [
+    {
+      "HandlerType": "Watcher",
+      "Initial": "",
+      "UtcTimeOn": "00:00:00",
+      "UtcTimeOff": "24:00:00",
+      "Loop": true,
+      "TimeLineEvents": [
         {
-            "HandlerType": "Watcher",
-            "Initial": "",
-            "UtcTimeOn": "00:00:00",
-            "UtcTimeOff": "24:00:00",
-            "Loop": true,
-            "TimeLineEvents": [
-                {
-                    "Command": "file",
-                    "CommandArgs": ["C:\\Temp\\test.txt", "300000"],
-                    "DelayAfter": 0,
-                    "DelayBefore": 0
-                }
-            ]
+          "Command": "file",
+          "CommandArgs": [ "C:\\Temp\\test.txt", "300000" ],
+          "DelayAfter": 0,
+          "DelayBefore": 0
         }
-    ]
+      ]
+    },
+    {
+      "HandlerType": "Watcher",
+      "Initial": "",
+      "UtcTimeOn": "00:00:00",
+      "UtcTimeOff": "24:00:00",
+      "Loop": true,
+      "TimeLineEvents": [
+        {
+          "Command": "folder",
+          "CommandArgs": [ "path:%HOMEDRIVE%%HOMEPATH%\\Downloads", "size:2000", "deletionApproach:oldest" ],
+          "DelayAfter": 0,
+          "DelayBefore": 0
+        }
+      ]
+    }
+  ]
 }

--- a/src/Ghosts.Client/config/timeline.json
+++ b/src/Ghosts.Client/config/timeline.json
@@ -2,29 +2,20 @@
   "Status": "Run",
   "TimeLineHandlers": [
     {
-      "HandlerType": "Ssh",
-      "HandlerArgs": {
-                "CommandTimeout": 1000,
-                "TimeBetweenCommandsMax": 5000,
-                "TimeBetweenCommandsMin": 1000,
-                "ValidExts": "txt;doc;png;jpeg",
-                "CredentialsFile": "d:\\ghosts_data\\creds.json",
-             },
+      "HandlerType": "Watcher",
       "Initial": "",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",
-      "Loop": "True",
+      "Loop": true,
       "TimeLineEvents": [
         {
-          "Command": "random",
-          "CommandArgs": [
-            "10.200.128.135|10.200.128.135_ncraf|ls -lah;ls -ltrh;help;pwd"
-          ],
-          "DelayAfter": 20000,
+          "Command": "folder",
+          "CommandArgs": [ "path:D:\\ghosts_test", "size:100", "deletionApproach:oldest" ],
+          "DelayAfter": 0,
           "DelayBefore": 0
         }
       ]
-    }
+    }, 
 
   ]
 }

--- a/src/Ghosts.Client/config/timeline.json
+++ b/src/Ghosts.Client/config/timeline.json
@@ -10,7 +10,7 @@
       "TimeLineEvents": [
         {
           "Command": "folder",
-          "CommandArgs": [ "path:D:\\ghosts_test", "size:100", "deletionApproach:largest" ],
+          "CommandArgs": [ "path:%HOMEDRIVE%%HOMEPATH%\\Downloads", "size:2000", "deletionApproach:oldest" ],
           "DelayAfter": 0,
           "DelayBefore": 0
         }

--- a/src/Ghosts.Client/config/timeline.json
+++ b/src/Ghosts.Client/config/timeline.json
@@ -10,7 +10,7 @@
       "TimeLineEvents": [
         {
           "Command": "folder",
-          "CommandArgs": [ "path:D:\\ghosts_test", "size:100", "deletionApproach:oldest" ],
+          "CommandArgs": [ "path:D:\\ghosts_test", "size:100", "deletionApproach:largest" ],
           "DelayAfter": 0,
           "DelayBefore": 0
         }


### PR DESCRIPTION
The 'folder' command for Watcher is intended to monitor diskspace in a target folder

The CommandArgs are in key:value pairs
path:<some folder>  - folder to watch
 size:<max size in MB> - maximum folder size in MB
deletionApproach:oldest|largest|random

If max size is exceeded, then files are deleted from the folder using the deletionApproach
 until the folder size is under max size.
 One obvious use of this is to monitor the browser downloads directory, i.e.
path:%HOMEDRIVE%%HOMEPATH%\\Downloads
 The deletion action can result in deleting a file that is in the progress of being downloaded
 which results in a failed download by the browser for this file. But since the goal is
traffic generation, this is not a deal breaker.  

Sample Handler:
```
{
      "HandlerType": "Watcher",
      "Initial": "",
      "UtcTimeOn": "00:00:00",
      "UtcTimeOff": "24:00:00",
      "Loop": true,
      "TimeLineEvents": [
        {
          "Command": "folder",
          "CommandArgs": [ "path:%HOMEDRIVE%%HOMEPATH%\\Downloads", "size:2000", "deletionApproach:oldest" ],
          "DelayAfter": 0,
          "DelayBefore": 0
        }
      ]
    }
```