### PR TITLE
SFTP support, Browser randomalt

### DIFF
--- a/src/Ghosts.Client/Ghosts.Client.csproj
+++ b/src/Ghosts.Client/Ghosts.Client.csproj
@@ -650,6 +650,7 @@
     <None Include="Sample Timelines\PowerPoint.json" />
     <None Include="Sample Timelines\Print.json" />
     <None Include="Sample Timelines\Reboot.json" />
+    <None Include="Sample Timelines\Sftp.json" />
     <None Include="Sample Timelines\Ssh.json" />
     <None Include="Sample Timelines\trackables timeline.json" />
     <None Include="Sample Timelines\watcher.json" />

--- a/src/Ghosts.Client/Ghosts.Client.csproj
+++ b/src/Ghosts.Client/Ghosts.Client.csproj
@@ -545,6 +545,7 @@
     <Compile Include="Handlers\BlogHelperDrupal.cs" />
     <Compile Include="Handlers\BrowserCrawl.cs" />
     <Compile Include="Handlers\Print.cs" />
+    <Compile Include="Handlers\Sftp.cs" />
     <Compile Include="Handlers\SharepointHelper.cs" />
     <Compile Include="Handlers\Ssh.cs" />
     <Compile Include="Infrastructure\Browser\BlogContent.cs" />
@@ -556,6 +557,7 @@
     <Compile Include="Infrastructure\ClientConfigurationResolver.cs" />
     <Compile Include="Infrastructure\KnownFolders.cs" />
     <Compile Include="Infrastructure\OfficeHelpers.cs" />
+    <Compile Include="Infrastructure\SftpSupport.cs" />
     <Compile Include="Infrastructure\SshSupport.cs" />
     <Compile Include="Infrastructure\TempFiles.cs" />
     <Compile Include="Handlers\Clicks.cs" />

--- a/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
+++ b/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
@@ -249,6 +249,7 @@ namespace Ghosts.Client.Handlers
                     this.linkManager.SetCurrent(config.Uri);
                     MakeRequest(config);
                     Report(handler.HandlerType.ToString(), timelineEvent.Command, config.ToString(), timelineEvent.TrackableId);
+                    Thread.Sleep(timelineEvent.DelayAfter);
 
                     if (this.stickiness > 0)
                     {
@@ -477,6 +478,7 @@ namespace Ghosts.Client.Handlers
                     urlQueue = new LifoQueue<Uri>(visitedRemember);
                     MakeRequest(config);
                     Report(handler.HandlerType.ToString(), timelineEvent.Command, config.ToString(), timelineEvent.TrackableId);
+                    Thread.Sleep(timelineEvent.DelayAfter);
 
                     if (this.stickiness > 0)
                     {

--- a/src/Ghosts.Client/Handlers/BlogHelper.cs
+++ b/src/Ghosts.Client/Handlers/BlogHelper.cs
@@ -221,6 +221,11 @@ namespace Ghosts.Client.Handlers
                         baseHandler.blogAbort = true;
                         return;
                     }
+                    if (handler.HandlerArgs.ContainsKey("delay-jitter"))
+                    {
+                        baseHandler.jitterfactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
+                    }
+
 
                     credFname = handler.HandlerArgs["blog-credentials-file"].ToString();
 

--- a/src/Ghosts.Client/Handlers/BlogHelperDrupal.cs
+++ b/src/Ghosts.Client/Handlers/BlogHelperDrupal.cs
@@ -1,7 +1,7 @@
 ﻿using Ghosts.Domain;
 using Ghosts.Domain.Code;
 using OpenQA.Selenium;
-using OpenQA.Selenium.DevTools.V101.Overlay;
+//using OpenQA.Selenium.DevTools.V101.Overlay;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Ghosts.Client/Handlers/BrowserChrome.cs
+++ b/src/Ghosts.Client/Handlers/BrowserChrome.cs
@@ -108,6 +108,8 @@ namespace Ghosts.Client.Handlers
 
             options.AddLocalStatePreference("download.default_directory", @"%homedrive%%homepath%\\Downloads");
             options.AddLocalStatePreference("disable-popup-blocking", "true");
+            
+
             options.BinaryLocation = GetInstallLocation();
 
             if (handler.HandlerArgs != null)
@@ -174,6 +176,8 @@ namespace Ghosts.Client.Handlers
             options.AddUserProfilePreference("download.directory_upgrade", true);
             options.AddUserProfilePreference("plugins.plugins_disabled", "Chrome PDF Viewer");
             options.AddUserProfilePreference("plugins.always_open_pdf_externally", true);
+            options.AddUserProfilePreference("safebrowsing.enabled", "false");  //this stops the confirmation popup when downloading files like .exe, .xml,etc
+            
 
 
             if (!string.IsNullOrEmpty(Program.Configuration.ChromeExtensions))

--- a/src/Ghosts.Client/Handlers/BrowserFirefox.cs
+++ b/src/Ghosts.Client/Handlers/BrowserFirefox.cs
@@ -10,6 +10,9 @@ using System.IO;
 using System.Threading;
 using Ghosts.Domain.Code.Helpers;
 using Newtonsoft.Json.Linq;
+using Ghosts.Domain.Code;
+using System.Text.RegularExpressions;
+using System.Runtime.InteropServices;
 
 namespace Ghosts.Client.Handlers
 {
@@ -19,6 +22,12 @@ namespace Ghosts.Client.Handlers
         {
             base.Init(handler);
             BrowserType = HandlerType.BrowserFirefox;
+            StartEx(handler);
+            
+        }
+
+        public virtual void StartEx(TimelineHandler handler)
+        {
             var hasRunSuccessfully = false;
             while (!hasRunSuccessfully)
             {
@@ -56,7 +65,49 @@ namespace Ghosts.Client.Handlers
             return true;
         }
 
-        private bool FirefoxEx(TimelineHandler handler)
+        public override void HandleBrowserException(Exception e)
+        {
+            if (e.Message.Contains("InsecureCertificate"))
+            {
+                HandleInsecureCertificate();
+            }
+        }
+
+        public void HandleInsecureCertificate()
+        {
+            //look for security override
+            IWebElement targetElement;
+            try
+            {
+                Thread.Sleep(500);
+                targetElement = Driver.FindElement(By.Id("advancedButton"));
+                BrowserHelperSupport.MoveToElementAndClick(Driver, targetElement); //click advanced 
+                Thread.Sleep(500);
+            }
+            catch
+            {
+                return; //return if not present
+            }
+            try { 
+                targetElement = Driver.FindElement(By.Id("exceptionDialogButton"));  
+                BrowserHelperSupport.MoveToElementAndClick(Driver, targetElement);   //accept risk and continue
+                Thread.Sleep(1000);
+                return;
+            }
+            catch { }
+            //look for return button
+            try
+            {
+                targetElement = Driver.FindElement(By.Id("advancedPanelReturnButton"));
+                BrowserHelperSupport.MoveToElementAndClick(Driver, targetElement);   //return, cannot continue
+                Thread.Sleep(1000);
+                
+            }
+            catch { }
+
+        }
+
+        public bool FirefoxEx(TimelineHandler handler)
         {
             try
             {
@@ -136,12 +187,17 @@ namespace Ghosts.Client.Handlers
 
                 if (this.Restart)
                 {
-                    Thread.Sleep(2000);
-                    _ = new BrowserFirefox(handler);
+                    DoRestart(handler);
                 }
             }
 
             return true;
+        }
+
+        public virtual void DoRestart(TimelineHandler handler)
+        {
+            Thread.Sleep(2000);
+            _ = new BrowserFirefox(handler);
         }
 
         internal static IWebDriver GetDriver(TimelineHandler handler)
@@ -158,6 +214,7 @@ namespace Ghosts.Client.Handlers
             options.AddArguments("--disable-infobars");
             options.AddArguments("--disable-extensions");
             options.AddArguments("--disable-notifications");
+            //options.AddArguments("--remote-debugging-port=0");
             if (handler.HandlerArgs.ContainsKey("command-line-args"))
             {
                 foreach (var option in (JArray)handler.HandlerArgs["command-line-args"])

--- a/src/Ghosts.Client/Handlers/BrowserFirefox.cs
+++ b/src/Ghosts.Client/Handlers/BrowserFirefox.cs
@@ -67,7 +67,7 @@ namespace Ghosts.Client.Handlers
 
         public override void HandleBrowserException(Exception e)
         {
-            if (e.Message.Contains("InsecureCertificate"))
+            if (e.Message.Contains("InsecureCertificate") || e.Message.Contains("Reached error page:"))
             {
                 HandleInsecureCertificate();
             }

--- a/src/Ghosts.Client/Handlers/Sftp.cs
+++ b/src/Ghosts.Client/Handlers/Sftp.cs
@@ -44,17 +44,6 @@ namespace Ghosts.Client.Handlers
                         }
                     }
                    
-                    if (handler.HandlerArgs.ContainsKey("CommandTimeout"))
-                    {
-                        try
-                        {
-                            this.CurrentSftpSupport.CommandTimeout = Int32.Parse(handler.HandlerArgs["CommandTimeout"].ToString());
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(e);
-                        }
-                    }
                     if (handler.HandlerArgs.ContainsKey("TimeBetweenCommandsMax"))
                     {
                         try
@@ -197,7 +186,7 @@ namespace Ghosts.Client.Handlers
                     {
                         try
                         {
-                            this.CurrentSftpSupport.RunSftpCommand(client, sftpCmd);
+                            this.CurrentSftpSupport.RunSftpCommand(client, sftpCmd.Trim());
                             if (this.CurrentSftpSupport.TimeBetweenCommandsMin != 0 && this.CurrentSftpSupport.TimeBetweenCommandsMax != 0 && this.CurrentSftpSupport.TimeBetweenCommandsMin < this.CurrentSftpSupport.TimeBetweenCommandsMax)
                             {
                                 Thread.Sleep(_random.Next(this.CurrentSftpSupport.TimeBetweenCommandsMin, this.CurrentSftpSupport.TimeBetweenCommandsMax));

--- a/src/Ghosts.Client/Handlers/Sftp.cs
+++ b/src/Ghosts.Client/Handlers/Sftp.cs
@@ -14,38 +14,22 @@ using Newtonsoft.Json;
 using Ghosts.Domain.Code;
 using WorkingHours = Ghosts.Client.Infrastructure.WorkingHours;
 
-/*
- * Used Package Renci.sshNet
- * Installed via packag manager
- * Install-Package SSH.NET
- * 
- */
-
 namespace Ghosts.Client.Handlers
 {
-    /// <summary>
-    /// This handler connects to a remote host and executes SSH commands.
-    /// This uses the Credentials class that keeps a simple dictionary of credentials
-    /// For SSH, is  uses the Renci.sshNet package, install via PM with Install-Package SSH.NET
-    /// The SSH connection uses a ShellStream for executing commands once a connection is established.
-    /// Each SSH shell command can have reserved words in it, such as '[remotedirectory]' which 
-    /// is replaced by a random remote directory on the server.  So 'cd [remotedirectory]' will change
-    /// to a random remote directory. 
-    /// See the Sample Timelines/Ssh.json for a sample timeline using this handler.
-    /// </summary>
-    public class Ssh : BaseHandler
+    public class Sftp : BaseHandler
     {
 
         private Credentials CurrentCreds = null;
-        private SshSupport CurrentSshSupport = null;   //current SshSupport for this object
+        private SftpSupport CurrentSftpSupport = null;   //current SftpSupport for this object
         public int jitterfactor = 0;
 
-        public Ssh(TimelineHandler handler)
+
+        public Sftp(TimelineHandler handler)
         {
             try
             {
                 base.Init(handler);
-                this.CurrentSshSupport = new SshSupport();
+                this.CurrentSftpSupport = new SftpSupport();
                 if (handler.HandlerArgs != null)
                 {
                     if (handler.HandlerArgs.ContainsKey("CredentialsFile"))
@@ -59,22 +43,12 @@ namespace Ghosts.Client.Handlers
                             Log.Error(e);
                         }
                     }
-                    if (handler.HandlerArgs.ContainsKey("ValidExts"))
-                    {
-                        try
-                        {
-                            this.CurrentSshSupport.ValidExts = handler.HandlerArgs["ValidExts"].ToString().Split(';');
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(e);
-                        }
-                    }
+                   
                     if (handler.HandlerArgs.ContainsKey("CommandTimeout"))
                     {
                         try
                         {
-                            this.CurrentSshSupport.CommandTimeout = Int32.Parse(handler.HandlerArgs["CommandTimeout"].ToString());
+                            this.CurrentSftpSupport.CommandTimeout = Int32.Parse(handler.HandlerArgs["CommandTimeout"].ToString());
                         }
                         catch (Exception e)
                         {
@@ -85,8 +59,8 @@ namespace Ghosts.Client.Handlers
                     {
                         try
                         {
-                            this.CurrentSshSupport.TimeBetweenCommandsMax = Int32.Parse(handler.HandlerArgs["TimeBetweenCommandsMax"].ToString());
-                            if (this.CurrentSshSupport.TimeBetweenCommandsMax < 0) this.CurrentSshSupport.TimeBetweenCommandsMax = 0;
+                            this.CurrentSftpSupport.TimeBetweenCommandsMax = Int32.Parse(handler.HandlerArgs["TimeBetweenCommandsMax"].ToString());
+                            if (this.CurrentSftpSupport.TimeBetweenCommandsMax < 0) this.CurrentSftpSupport.TimeBetweenCommandsMax = 0;
                         }
                         catch (Exception e)
                         {
@@ -97,14 +71,35 @@ namespace Ghosts.Client.Handlers
                     {
                         try
                         {
-                            this.CurrentSshSupport.TimeBetweenCommandsMin = Int32.Parse(handler.HandlerArgs["TimeBetweenCommandsMin"].ToString());
-                            if (this.CurrentSshSupport.TimeBetweenCommandsMin < 0) this.CurrentSshSupport.TimeBetweenCommandsMin = 0;
+                            this.CurrentSftpSupport.TimeBetweenCommandsMin = Int32.Parse(handler.HandlerArgs["TimeBetweenCommandsMin"].ToString());
+                            if (this.CurrentSftpSupport.TimeBetweenCommandsMin < 0) this.CurrentSftpSupport.TimeBetweenCommandsMin = 0;
                         }
                         catch (Exception e)
                         {
                             Log.Error(e);
                         }
                     }
+                    if (handler.HandlerArgs.ContainsKey("UploadDirectory"))
+                    {
+                        string targetDir = handler.HandlerArgs["UploadDirectory"].ToString();
+                        targetDir = Environment.ExpandEnvironmentVariables(targetDir);
+                        if (!Directory.Exists(targetDir))
+                        {
+                            Log.Trace($"Sftp:: upload directory {targetDir} does not exist, using browser downloads directory.");
+                        }
+                        else
+                        {
+                            this.CurrentSftpSupport.uploadDirectory = targetDir;
+                        }
+                    }
+
+                    if (this.CurrentSftpSupport.uploadDirectory == null)
+                    {
+                        this.CurrentSftpSupport.uploadDirectory = KnownFolders.GetDownloadFolderPath();
+                    }
+
+                    this.CurrentSftpSupport.downloadDirectory = KnownFolders.GetDownloadFolderPath();
+
                     if (handler.HandlerArgs.ContainsKey("delay-jitter"))
                     {
                         jitterfactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
@@ -128,7 +123,7 @@ namespace Ghosts.Client.Handlers
             catch (ThreadAbortException)
             {
                 ProcessManager.KillProcessAndChildrenByName(ProcessManager.ProcessNames.Command);
-                Log.Trace("Ssh closing...");
+                Log.Trace("Sftp closing...");
             }
             catch (Exception e)
             {
@@ -145,7 +140,7 @@ namespace Ghosts.Client.Handlers
                 if (timelineEvent.DelayBefore > 0)
                     Thread.Sleep(timelineEvent.DelayBefore);
 
-                Log.Trace($"SSH Command: {timelineEvent.Command} with delay after of {timelineEvent.DelayAfter}");
+                Log.Trace($"Sftp Command: {timelineEvent.Command} with delay after of {timelineEvent.DelayAfter}");
 
                 switch (timelineEvent.Command)
                 {
@@ -169,21 +164,22 @@ namespace Ghosts.Client.Handlers
 
         public void Command(TimelineHandler handler, TimelineEvent timelineEvent, string command)
         {
-            
+
             char[] charSeparators = new char[] { '|' };
-            var cmdArgs = command.Split(charSeparators, 3,StringSplitOptions.None);
+            var cmdArgs = command.Split(charSeparators, 3, StringSplitOptions.None);
             var hostIp = cmdArgs[0];
+            this.CurrentSftpSupport.HostIp = hostIp; //for trace output
             var credKey = cmdArgs[1];
-            var sshCmds = cmdArgs[2].Split(';');
+            var sftpCmds = cmdArgs[2].Split(';');
             var username = this.CurrentCreds.GetUsername(credKey);
             var password = this.CurrentCreds.GetPassword(credKey);
-            Log.Trace("Beginning SSH to host:  " + hostIp + " with command: " + command);
+            Log.Trace("Beginning Sftp to host:  " + hostIp + " with command: " + command);
 
             if (username != null && password != null)
             {
-                
+
                 //have IP, user/pass, try connecting 
-                using (var client = new SshClient(hostIp, username, password))
+                using (var client = new SftpClient(hostIp, username, password))
                 {
                     try
                     {
@@ -195,14 +191,17 @@ namespace Ghosts.Client.Handlers
                         return;  //unable to connect
                     }
                     //we are connected, execute the commands
-                    ShellStream shellStreamSSH = client.CreateShellStream("vt220", 80, 60, 800, 600, 65536);
-                    //before running commands, flush the input of welcome login text
-                    this.CurrentSshSupport.GetSshCommandOutput(shellStreamSSH, true);
-                    foreach (var sshCmd in sshCmds)
+                    
+                    
+                    foreach (var sftpCmd in sftpCmds)
                     {
                         try
                         {
-                            this.CurrentSshSupport.RunSshCommand(shellStreamSSH, sshCmd);
+                            this.CurrentSftpSupport.RunSftpCommand(client, sftpCmd);
+                            if (this.CurrentSftpSupport.TimeBetweenCommandsMin != 0 && this.CurrentSftpSupport.TimeBetweenCommandsMax != 0 && this.CurrentSftpSupport.TimeBetweenCommandsMin < this.CurrentSftpSupport.TimeBetweenCommandsMax)
+                            {
+                                Thread.Sleep(_random.Next(this.CurrentSftpSupport.TimeBetweenCommandsMin, this.CurrentSftpSupport.TimeBetweenCommandsMax));
+                            }
                         }
                         catch (Exception e)
                         {
@@ -218,9 +217,5 @@ namespace Ghosts.Client.Handlers
         }
 
 
-
-
-
     }
-
 }

--- a/src/Ghosts.Client/Handlers/SharepointHelper.cs
+++ b/src/Ghosts.Client/Handlers/SharepointHelper.cs
@@ -603,6 +603,15 @@ namespace Ghosts.Client.Handlers
         /// <param name="targetElement"></param>
         public void MoveToElementAndClick(IWebElement targetElement)
         {
+            BrowserHelperSupport.MoveToElementAndClick(Driver, targetElement);
+        }
+
+    }
+
+    public class BrowserHelperSupport
+    {
+        public static void MoveToElementAndClick(IWebDriver Driver, IWebElement targetElement)
+        {
             Actions actions;
 
             if (Driver is OpenQA.Selenium.Firefox.FirefoxDriver)
@@ -618,4 +627,4 @@ namespace Ghosts.Client.Handlers
 
     }
 
-}
+    }

--- a/src/Ghosts.Client/Handlers/SharepointHelper.cs
+++ b/src/Ghosts.Client/Handlers/SharepointHelper.cs
@@ -444,6 +444,10 @@ namespace Ghosts.Client.Handlers
                         baseHandler.sharepointAbort = true;
                         return;
                     }
+                    if (handler.HandlerArgs.ContainsKey("delay-jitter"))
+                    {
+                        baseHandler.jitterfactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
+                    }
 
                     credFname = handler.HandlerArgs["sharepoint-credentials-file"].ToString();
 

--- a/src/Ghosts.Client/Handlers/Ssh.cs
+++ b/src/Ghosts.Client/Handlers/Ssh.cs
@@ -11,6 +11,8 @@ using Ghosts.Domain;
 using System.Net;
 using System.Diagnostics;
 using Newtonsoft.Json;
+using Ghosts.Domain.Code;
+using WorkingHours = Ghosts.Client.Infrastructure.WorkingHours;
 
 /*
  * Used Package Renci.sshNet
@@ -36,6 +38,7 @@ namespace Ghosts.Client.Handlers
 
         private Credentials CurrentCreds = null;
         private SshSupport CurrentSshSupport = null;   //current SshSupport for this object
+        public int jitterfactor = 0;
 
         public Ssh(TimelineHandler handler)
         {
@@ -102,6 +105,10 @@ namespace Ghosts.Client.Handlers
                             Log.Error(e);
                         }
                     }
+                    if (handler.HandlerArgs.ContainsKey("delay-jitter"))
+                    {
+                        jitterfactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
+                    }
                 }
 
 
@@ -150,7 +157,7 @@ namespace Ghosts.Client.Handlers
                             {
                                 this.Command(handler, timelineEvent, cmd.ToString());
                             }
-                            Thread.Sleep(timelineEvent.DelayAfter);
+                            Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayAfter, jitterfactor)); ;
                         }
                     default:
                         this.Command(handler, timelineEvent, timelineEvent.Command);
@@ -162,7 +169,7 @@ namespace Ghosts.Client.Handlers
                 }
 
                 if (timelineEvent.DelayAfter > 0)
-                    Thread.Sleep(timelineEvent.DelayAfter);
+                    Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayAfter, jitterfactor)); ;
             }
         }
 

--- a/src/Ghosts.Client/Handlers/Ssh.cs
+++ b/src/Ghosts.Client/Handlers/Ssh.cs
@@ -202,7 +202,7 @@ namespace Ghosts.Client.Handlers
                     {
                         try
                         {
-                            this.CurrentSshSupport.RunSshCommand(shellStreamSSH, sshCmd);
+                            this.CurrentSshSupport.RunSshCommand(shellStreamSSH, sshCmd.Trim());
                         }
                         catch (Exception e)
                         {

--- a/src/Ghosts.Client/Infrastructure/SftpSupport.cs
+++ b/src/Ghosts.Client/Infrastructure/SftpSupport.cs
@@ -1,0 +1,313 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Ghosts.Client.Handlers;
+using Renci.SshNet;
+using Renci.SshNet.Sftp;
+using static System.Net.WebRequestMethods;
+
+namespace Ghosts.Client.Infrastructure
+{
+    public class SftpSupport : SshSftpSupport
+    {
+       
+        public string uploadDirectory { get; set; } = null;
+        public string downloadDirectory { get; set; } = null;
+
+
+        public string GetUploadFilename()
+        {
+            try
+            {
+                string[] filelist = Directory.GetFiles(uploadDirectory, "*");
+                if (filelist.Length > 0) return filelist[_random.Next(0, filelist.Length)];
+                else return null;
+            }
+            catch { } //ignore any errors
+            return null;
+        }
+
+        public SftpFile GetRemoteFile(SftpClient client)
+        {
+
+            try
+            {
+                var remoteFiles = client.ListDirectory(".").ToList<SftpFile>();
+                List<SftpFile> normalFiles = new List<SftpFile>();
+                foreach (var f in remoteFiles)
+                {
+                    if (f.IsDirectory || f.IsSymbolicLink) continue;
+                    if (f.IsRegularFile) normalFiles.Add(f);
+                }
+                if (normalFiles.Count > 0)
+                {
+                    return normalFiles[_random.Next(0, normalFiles.Count())];
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+            }
+            return null;
+
+        }
+
+        public SftpFile GetRemoteDir(SftpClient client)
+        {
+
+            try
+            {
+                var remoteFiles = client.ListDirectory(".").ToList<SftpFile>();
+                List<SftpFile> normalFiles = new List<SftpFile>();
+                foreach (var f in remoteFiles)
+                {
+                    if (f.IsRegularFile || f.IsSymbolicLink) continue;
+                    if (f.IsDirectory) normalFiles.Add(f);
+                }
+                if (normalFiles.Count > 0)
+                {
+                    return normalFiles[_random.Next(0, remoteFiles.Count())];
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+            }
+            return null;
+
+        }
+
+        /// <summary>
+        /// Replaces reserved words in command string with a value
+        /// Reserved words are marked in command string like [reserved_word]
+        /// Supported reserved words:
+        ///  localfile --  substituted with random file from local uploadDirectory
+        ///  remotefile -- substituted with random file from remote current directory
+        ///  
+        ///  
+        /// 
+        /// This may require execution and parsing of an internal sftp command before returning
+        /// the new command
+        /// </summary> 
+        /// <param name="cmd"></param>  - string parse for reserved words
+        /// <returns></returns>
+        private string ParseSftpCmd(SftpClient client, string cmd)
+        {
+            string currentcmd = cmd;
+            if (currentcmd.Contains("[localfile]"))
+            {
+                var fname = GetUploadFilename();
+                if (fname == null)
+                {
+                    Log.Trace($"Sft[:: Cannot find a valid file to upload from directory {uploadDirectory}.");
+                    return null;
+                }
+                currentcmd = currentcmd.Replace("[localfile]", fname);
+
+            }
+            if (currentcmd.Contains("[remotefile]"))
+            {
+                var file = GetRemoteFile(client);
+                currentcmd = currentcmd.Replace("[remotefile]", file.FullName); //use full name
+            }
+
+                return currentcmd;
+        }
+
+        /// <summary>
+        /// Expecting a string of 'put filename'
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="cmd"></param>
+        public void DoPut(SftpClient client, string cmd)
+        {
+            char[] charSeparators = new char[] { ' ' };
+            var cmdArgs = cmd.Split(charSeparators, 2, StringSplitOptions.None);
+            if (cmdArgs.Length != 2)
+            {
+                Log.Trace($"Sftp:: ill-formatted put command: {cmd} ");
+                return;
+            }
+            var fileName = cmdArgs[1];
+            if (fileName.Contains("[localfile]") ){
+                fileName = GetUploadFilename();
+                if (fileName == null)
+                {
+                    Log.Trace($"Sft[:: Cannot find a valid file to upload from directory {uploadDirectory}.");
+                    return;
+                }
+            }
+
+            try
+            {
+                using (var fileStream = System.IO.File.OpenRead(fileName))
+                {
+                    var components = fileName.Split(Path.DirectorySeparatorChar);
+                    var remoteFileName = components[components.Length - 1];
+                    client.UploadFile(fileStream, remoteFileName, true);
+                    Log.Trace($"Sftp:: Uploaded local file {fileName} to file {remoteFileName}, host {this.HostIp} ");
+                    fileStream.Close();
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+            }
+        }
+
+        /// <summary>
+        /// Expecting a string of 'get filename'
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="cmd"></param>
+        public void DoGet(SftpClient client, string cmd)
+        {
+            char[] charSeparators = new char[] { ' ' };
+            var cmdArgs = cmd.Split(charSeparators, 2, StringSplitOptions.None);
+            if (cmdArgs.Length != 2)
+            {
+                Log.Trace($"Sftp:: ill-formatted put command: {cmd} ");
+                return;
+            }
+            var fileName = cmdArgs[1];
+            string localFilePath = null;
+            string remoteFilePath = null;
+            if (fileName.Contains("[remotefile]"))
+            {
+                SftpFile file = GetRemoteFile(client);
+                if (file == null)
+                {
+                    Log.Trace($"Sft[:: Cannot find a valid file to download from remote host {this.HostIp}.");
+                    return;
+                }
+                remoteFilePath = file.FullName;
+                localFilePath = Path.Combine(downloadDirectory, file.Name);
+            }
+            else
+            {
+                var seperator = '\\';
+                if (fileName.Contains("\\"))
+                {
+                    //assume this the full path to a windows box
+                    remoteFilePath = fileName;
+                } else if (fileName.Contains("/"))
+                {
+                    remoteFilePath = fileName;
+                    seperator = '/';
+                }
+                if  (remoteFilePath == null)
+                {
+                    //a local name
+                    remoteFilePath = fileName;
+                    localFilePath = Path.Combine(downloadDirectory, fileName);
+                } else
+                {
+                    remoteFilePath = fileName;
+                    //parse fullpath to get local name
+                    var components = fileName.Split(seperator);
+                    localFilePath = Path.Combine(downloadDirectory, components[components.Length - 1]);
+                }
+            }
+            //at this point, localFilePath, remoteFilePath are set
+            if (System.IO.File.Exists(localFilePath))
+            {
+                try
+                {
+                    //delete the file if exists locally
+                    System.IO.File.Delete(localFilePath);
+                } 
+                catch (Exception e)
+                {
+                    Log.Error(e);
+                    return;
+                }
+            }
+            //now download the file
+            try
+            {
+                using (var fileStream = System.IO.File.OpenWrite(localFilePath))
+                {
+                    client.DownloadFile(remoteFilePath, fileStream);
+                    Log.Trace($"Sftp:: Downloaded remote file {remoteFilePath},host {this.HostIp}  to file {localFilePath},  ");
+                    fileStream.Close();
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+            }
+        }
+
+        public void DoChangeDir(SftpClient client, string cmd)
+        {
+            char[] charSeparators = new char[] { ' ' };
+            var cmdArgs = cmd.Split(charSeparators, 2, StringSplitOptions.None);
+            if (cmdArgs.Length != 2)
+            {
+                Log.Trace($"Sftp:: ill-formatted cd command: {cmd} ");
+                return;
+            }
+            var dirName = cmdArgs[1];
+            if (dirName.Contains("[remotedir]"))
+            {
+                SftpFile file = GetRemoteFile(client);
+                if (file == null)
+                {
+                    Log.Trace($"Sft[:: Cannot find a valid directory to change to on remote host {this.HostIp}.");
+                    return;
+                }
+                dirName = file.FullName;
+            }
+            
+            try
+            {
+                client.ChangeDirectory(dirName);
+                
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+            }
+
+        }
+
+        /// <summary>
+        /// Supported commands:
+        /// get [remotefile] - downloads random remote file from remote host. Can specify absolute/relative path instead of [remotefile]
+        /// put [localfile] - uploads random remote file from local upload directory to remote host. Can specify absolute/relative path instead of [localfile]
+        /// cd [remotedir] - change to random directory in current directory on remote host. Can specify absolute/relative path instead of [remotedir]
+        /// rm [remotefile] - deletes random remote file from remote host. Can specify absolute/relative path instead of [remotefile]
+        /// ls  - list remote contents of current directory
+        /// mkdir [randomname] - make a random directory on remote host. Can specify absolute/relative path instead of [randomname]
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="cmd"></param>
+
+        public void RunSftpCommand(SftpClient client, string cmd)
+        {
+
+            if (cmd.StartsWith("put"))
+            {
+                DoPut(client, cmd);
+                return;
+            }
+            else if (cmd.StartsWith("get"))
+            {
+                DoGet(client, cmd);
+                return;
+            }
+            string newcmd = this.ParseSftpCmd(client, cmd);
+            if (newcmd == null) return;
+            
+            if (newcmd.StartsWith("cd")) DoChangeDir(client, newcmd);
+
+
+            return;
+        }
+
+    }
+}

--- a/src/Ghosts.Client/Infrastructure/SshSupport.cs
+++ b/src/Ghosts.Client/Infrastructure/SshSupport.cs
@@ -21,40 +21,6 @@ namespace Ghosts.Client.Infrastructure
         public string uploadDirectory { get; set; } = null;
 
 
-        private static string RandomString(int min, int max, bool lowercase = false)
-        {
-            var size = _random.Next(min, max);
-            var builder = new StringBuilder(size);
-            const int lettersOffset = 26; // A...Z or a..z: length=26  
-            char[] others = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
-
-            for (var i = 0; i < size; i++)
-            {
-                var choice = _random.Next(2);
-                char offset = choice == 0 ? 'a' : 'A';
-
-                if (i == 0 || _random.Next(10) < 7)
-                {
-                    var @char = (char)_random.Next(offset, offset + lettersOffset);
-                    builder.Append(@char);
-                }
-                else
-                {
-                    var @char = others[_random.Next(others.Length)];
-                    builder.Append(@char);
-                }
-
-            }
-            if (lowercase)
-            {
-                return builder.ToString().ToLower();
-            }
-            else
-            {
-                return builder.ToString();
-            }
-        }
-
 
         private string GetRandomDirectory(ShellStream client)
         {
@@ -202,6 +168,42 @@ namespace Ghosts.Client.Infrastructure
         public int CommandTimeout { get; set; } = 1000;
 
         public string HostIp { get; set; } = null;
+
+
+        public static string RandomString(int min, int max, bool lowercase = false)
+        {
+            var size = _random.Next(min, max);
+            var builder = new StringBuilder(size);
+            const int lettersOffset = 26; // A...Z or a..z: length=26  
+            char[] others = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+
+            for (var i = 0; i < size; i++)
+            {
+                var choice = _random.Next(2);
+                char offset = choice == 0 ? 'a' : 'A';
+
+                if (i == 0 || _random.Next(10) < 7)
+                {
+                    var @char = (char)_random.Next(offset, offset + lettersOffset);
+                    builder.Append(@char);
+                }
+                else
+                {
+                    var @char = others[_random.Next(others.Length)];
+                    builder.Append(@char);
+                }
+
+            }
+            if (lowercase)
+            {
+                return builder.ToString().ToLower();
+            }
+            else
+            {
+                return builder.ToString();
+            }
+        }
+
     }
 
 }

--- a/src/Ghosts.Client/Sample Timelines/Sftp.json
+++ b/src/Ghosts.Client/Sample Timelines/Sftp.json
@@ -1,0 +1,47 @@
+
+
+/// SFTP handler.
+/// Each CommandArg is of the formation shown below, if multiple CommandArgs are present a random one is chosen for execution on each cycle.
+/// Credential handling is done in the same manner as the SSH handler, see that sample timeline for documentation
+/// After the <cred_key> is a ';' delimited list of SFTP commands that are executed in sequence during a cycle.
+/// Downloaded files are placed in the user's default downloads directory
+/// Supported commands:
+/// get [remotefile] - downloads random remote file from remote host. Can specify absolute/relative path instead of [remotefile]
+/// put [localfile] - uploads random remote file from local upload directory to remote host. Can specify absolute/relative path instead of [localfile]
+/// cd [remotedir] - change to random directory in current directory on remote host. Can specify absolute/relative path instead of [remotedir]
+/// rm [remotefile] - deletes random remote file from remote host. Can specify absolute/relative path instead of [remotefile]
+/// ls [remotedir] - list remote contents of current directory, if no directory specified use current directory. Can specify absolute/relative path instead of [remotedir]
+/// mkdir [randomname] - make a random directory in cwd on remote host. Can specify absolute/relative path instead of [randomname]
+
+
+
+{
+  "Status": "Run",
+  "TimeLineHandlers": [
+    {
+      "HandlerType": "Sftp",
+      "HandlerArgs": {
+        "TimeBetweenCommandsMax": 5000, //max,min between individual SFTP commands
+        "TimeBetweenCommandsMin": 1000,
+        "CredentialsFile": "<path to credentials>", //required, file path to a JSON file containing the SSH credentials
+        "UploadDirectory": "<path to uploads directory>", //optional, directory that contains files for upload, it not specified user Downloads directory is used
+        "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
+      },
+      "Initial": "",
+      "UtcTimeOn": "00:00:00",
+      "UtcTimeOff": "24:00:00",
+      "Loop": "True",
+      "TimeLineEvents": [
+        {
+          "Command": "random",
+          "CommandArgs": [
+            "<someIp>|<credKey>|<a_cmd>;<a_cmd>;<a_cmd>....;<a_cmd>"
+          ],
+          "DelayAfter": 20000,
+          "DelayBefore": 0
+        }
+      ]
+    }
+
+  ]
+}

--- a/src/Ghosts.Client/Sample Timelines/Ssh.json
+++ b/src/Ghosts.Client/Sample Timelines/Ssh.json
@@ -13,7 +13,7 @@
 /// The Version slot string is unused at the moment but is there in case this implementation
 /// is extended in the future.
 /// The credkey is simply some unique string that identifies the credential.
-/// The password is assumed to be ASCII that is base64 encoded.
+/// The password is assumed to be UTF8 that is base64 encoded.
 /// See src\Ghosts.Client\Infrastructure\SshSupport.cs for a list [<reservedword>] supported in Ssh commands
 ///
 
@@ -26,12 +26,13 @@
     {
       "HandlerType": "Ssh",
       "HandlerArgs": {
-                "CommandTimeout": 1000,    //max time to wait for new input from an SSH command execution
-                "TimeBetweenCommandsMax": 5000, //max,min between individual SSH commands
-                "TimeBetweenCommandsMin": 1000,
-                "ValidExts": "txt;doc;png;jpeg", //used by [randomextension] reserved word, choose random extension from this list
-                "CredentialsFile": "d:\\ghosts_data\\ssh_creds.json",  //required, file path to a JSON file containing the SSH credentials
-             },
+        "CommandTimeout": 1000, //max time to wait for new input from an SSH command execution
+        "TimeBetweenCommandsMax": 5000, //max,min between individual SSH commands
+        "TimeBetweenCommandsMin": 1000,
+        "ValidExts": "txt;doc;png;jpeg", //used by [randomextension] reserved word, choose random extension from this list
+        "CredentialsFile": "d:\\ghosts_data\\ssh_creds.json", //required, file path to a JSON file containing the SSH credentials
+        "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
+      },
       "Initial": "",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",

--- a/src/Ghosts.Client/TimelineManager/Orchestrator.cs
+++ b/src/Ghosts.Client/TimelineManager/Orchestrator.cs
@@ -309,6 +309,12 @@ namespace Ghosts.Client.TimelineManager
                             _ = new Ssh(handler);
                         });
                         break;
+                    case HandlerType.Sftp:
+                        t = new Thread(() =>
+                        {
+                            _ = new Sftp(handler);
+                        });
+                        break;
                     case HandlerType.Word:
                         _log.Trace("Launching thread for word");
                         if (IsWordInstalled)

--- a/src/Ghosts.Domain/Code/Jitter.cs
+++ b/src/Ghosts.Domain/Code/Jitter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2017 Carnegie Mellon University. All Rights Reserved. See LICENSE.md file for terms.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Ghosts.Domain.Code
 {
@@ -54,5 +55,33 @@ namespace Ghosts.Domain.Code
                 sleep = 1;
             return sleep;
         }
+
+
+        /// <summary>
+        /// The jstring is expected to be a decimal integer string between 0 and 50
+        /// which represents a +/-%window about a base value
+        /// </summary>
+        /// <param name="jstring"></param>
+        /// <returns></returns>
+        public static int JitterFactorParse(string jstring)
+        {
+            int jitterFactor;
+            if (int.TryParse(jstring, out jitterFactor))
+            {
+                if (jitterFactor < 0 || jitterFactor > 50) jitterFactor = 0;
+            } else
+            {
+                jitterFactor = 0;
+            }
+                return jitterFactor;
+        }
+
+        public static int JitterFactorDelay(int baseSleep, int jitterFactor)
+        {
+            if (jitterFactor == 0) return baseSleep;
+            return _random.Next(baseSleep - ((baseSleep * jitterFactor) / 100), baseSleep + ((baseSleep * jitterFactor) / 100));
+        }
+
+
     }
 }

--- a/src/Ghosts.Domain/Messages/Timeline.cs
+++ b/src/Ghosts.Domain/Messages/Timeline.cs
@@ -93,7 +93,9 @@ namespace Ghosts.Domain
         LightPowerPoint = 33,
         Bash = 40,
         Print = 45,
-        Ssh = 100
+        Ssh = 100,
+        Sftp = 101,
+
     }
 
     /// <summary>


### PR DESCRIPTION
1. A new SFTP handler was added, this is similar to the SSH handler, using Renci.SSH.  See the new sample handler for documentation.

2. A new browser command was added, `randomalt`. This is similar to `random`, but supports our synthetic internet better. The changes are upward compatible, no changes were made to `random`, changes are encapsulated in the `randomalt command.

The `randomalt` command  is the same as `random` in that it picks a URL from the timeline and browses to that page, then uses the stickiness parameters to make successive accesses to that page.   It is here that the command differs from `random` in the following ways:

All links on the page are found, and a link is chosen at random with no preference to local links (this was needed on in our environment as our pages have  a lot of downloadable files, and this was giving too much preference to those links). Recently used links are rejected, the same as `random`. If no links are found, then it bounces back to choosing another link from the timeline.

After choosing a link, if a link ends in `htm` or `html`, then `Navigate().GotoUrl(`) is used, the same as random, else Javascript is used to click the link as it is assumed to be a downloadable file. This avoids a problem with Firefox and `GotoUrl` that causes browsing to halt after a file is downloaded using `Navigate().GotoUrl()`.

Only a GET action is currently supported for URLs on a `randomalt` timeline. This will be altered in the future to support POST actions, probably in a much different way than currently is done by random.

Other GHOSTS changes

The Firefox handler has been augmented to handle the security popups when an insecure certificate is detected (since Firefox has no way of disabling these popups). This was important in our synthetic internet in that we needed both Firefox and Chrome to work with insecure certificates.

The Chrome handler has a preference set to disable to download confirmation popup when downloading files such as .exe, .xml  etc.

