### PR TITLE
Fix issue where timelines continue executing after an NpcSystem stop command

### DIFF
--- a/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
+++ b/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
@@ -296,14 +296,14 @@ namespace Ghosts.Client.Handlers
                                     MakeRequest(config);
                                     Report(handler.HandlerType.ToString(), timelineEvent.Command, config.ToString(), timelineEvent.TrackableId);                                 
                                 }
-                                catch (ThreadAbortException)
-                                {
-                                    ProcessManager.KillProcessAndChildrenByName(this.BrowserType.ToString().Replace("Browser", ""));
-                                    Log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
-                                    return;
-                                }
                                 catch (Exception e)
                                 {
+                                    if (e is ThreadAbortException || e is ThreadInterruptedException)
+                                    {
+                                        ProcessManager.KillProcessAndChildrenByName(this.BrowserType.ToString().Replace("Browser", ""));
+                                        Log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
+                                        throw;
+                                    }
                                     Log.Error($"Browser loop error {e}");
                                 }
 

--- a/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
+++ b/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
@@ -201,13 +201,14 @@ namespace Ghosts.Client.Handlers
                     }
                 }
             }
-            catch (ThreadAbortException)
-            {
-                ProcessManager.KillProcessAndChildrenByName(this.BrowserType.ToString().Replace("Browser", ""));
-                Log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
-            }
             catch (Exception e)
             {
+                if (e is ThreadAbortException || e is ThreadInterruptedException)
+                {
+                    ProcessManager.KillProcessAndChildrenByName(this.BrowserType.ToString().Replace("Browser", ""));
+                    Log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
+                    throw;
+                }
                 Log.Error(e);
             }
         }
@@ -373,6 +374,10 @@ namespace Ghosts.Client.Handlers
             }
             catch (Exception e)
             {
+                if (e is ThreadAbortException || e is ThreadInterruptedException)
+                {
+                    throw;
+                }
                 Log.Trace(e);
             }
         }
@@ -409,6 +414,10 @@ namespace Ghosts.Client.Handlers
             }
             catch (Exception e)
             {
+                if (e is ThreadAbortException || e is ThreadInterruptedException)
+                {
+                    throw;
+                }
 
                 Log.Trace(e.Message);
                 HandleBrowserException(e);
@@ -555,6 +564,10 @@ namespace Ghosts.Client.Handlers
             }
             catch (Exception e)
             {
+                if (e is ThreadAbortException || e is ThreadInterruptedException)
+                {
+                    throw;
+                }
                 Log.Trace(e);
                 HandleBrowserException(e);
             }
@@ -625,14 +638,14 @@ namespace Ghosts.Client.Handlers
                                         Log.Trace($"Request skipped due to browse probability for #{loopNumber + 1}/{loops} to {config.Uri}");
                                     }
                                 }
-                                catch (ThreadAbortException)
-                                {
-                                    ProcessManager.KillProcessAndChildrenByName(this.BrowserType.ToString().Replace("Browser", ""));
-                                    Log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
-                                    return;
-                                }
                                 catch (Exception e)
                                 {
+                                    if (e is ThreadAbortException || e is ThreadInterruptedException)
+                                    {
+                                        ProcessManager.KillProcessAndChildrenByName(this.BrowserType.ToString().Replace("Browser", ""));
+                                        Log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
+                                        throw;
+                                    }
                                     Log.Error($"Browser loop error {e}");
                                 }
 

--- a/src/ghosts.client.linux/Handlers/BaseBrowserHandler.cs
+++ b/src/ghosts.client.linux/Handlers/BaseBrowserHandler.cs
@@ -247,12 +247,13 @@ namespace ghosts.client.linux.handlers
                     }
                 }
             }
-            catch (ThreadAbortException)
-            {
-                _log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
-            }
             catch (Exception e)
             {
+                if (e is ThreadAbortException || e is ThreadInterruptedException)
+                {
+                    _log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
+                    throw;
+                }
                 _log.Error(e);
             }
         }
@@ -284,6 +285,10 @@ namespace ghosts.client.linux.handlers
             }
             catch (Exception e)
             {
+                if (e is ThreadAbortException || e is ThreadInterruptedException)
+                {
+                    throw;
+                }
                 _log.Trace(e);
             }
         }
@@ -320,6 +325,10 @@ namespace ghosts.client.linux.handlers
             }
             catch (Exception e)
             {
+                if (e is ThreadAbortException || e is ThreadInterruptedException)
+                {
+                    throw;
+                }
                 _log.Trace(e.Message);
             }
         }

--- a/src/ghosts.client.linux/Handlers/BaseBrowserHandler.cs
+++ b/src/ghosts.client.linux/Handlers/BaseBrowserHandler.cs
@@ -138,13 +138,13 @@ namespace ghosts.client.linux.handlers
                                                     MakeRequest(config);
                                                     Report(handler.HandlerType.ToString(), timelineEvent.Command, config.ToString(), timelineEvent.TrackableId);
                                                 }
-                                                catch (ThreadAbortException)
-                                                {
-                                                    _log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
-                                                    return;
-                                                }
                                                 catch (Exception e)
                                                 {
+                                                    if (e is ThreadAbortException || e is ThreadInterruptedException)
+                                                    {
+                                                        _log.Trace($"Thread aborted, {this.BrowserType.ToString()} closing...");
+                                                        throw;
+                                                    }
                                                     _log.Error($"Browser loop error {e}");
                                                 }
 


### PR DESCRIPTION
This PR attempts to resolve an issue where after posting a MachineUpdate to /api/machineupdates with an NpcSystem stop command, the machine continues to execute the original timeline. The issue appears to be the `ThreadInterruptedException` being caught by methods further down in the call stack and not bubbling up to actually exit the thread.

We're currently using the Linux container, but I tried to resolve the issue for the Windows version as well. The only difference that I could find is Windows uses `Thread.Abort()` whereas Linux uses `Thread.Interrupt()`. I'm checking for both `ThreadAbortException` and `ThreadInterruptedException` in both cases to be sure though.

I don't have a Windows machine readily available at the moment to test those changes so let me know if there's anything I need to address.

Here's an example payload used to start the initial timeline:
```
{
  "machineId": "22f1a579-27f7-48a7-932e-1dcdd1dc4603",
  "type": 10,
  "activeUtc": "2023-01-11T16:03:14.996Z",
  "createdUtc": "2023-01-11T16:03:14.996Z",
  "update": "{\"Id\":\"b7c3b657-fd29-413c-ad44-3ddc09b4146f\",\"Status\":\"Run\",\"TimeLineHandlers\":[{\"HandlerType\":\"BrowserChrome\",\"Initial\":\"about:blank\",\"UtcTimeOn\":\"00:00:00\",\"UtcTimeOff\":\"24.00:00:00\",\"HandlerArgs\":{\"isheadless\":\"true\",\"blockimages\":\"false\",\"blockstyles\":\"false\",\"blockflash\":\"false\",\"blockscripts\":\"true\",\"stickiness\":0,\"stickiness-depth-min\":5,\"stickiness-depth-max\":10000,\"incognito\":\"false\",\"command-line-args\":[\"--disable-dev-shm-usage\",\"--no-sandbox\"]},\"Loop\":true,\"TimeLineEvents\":[{\"TrackableId\":null,\"Command\":\"random\",\"CommandArgs\":[\"http://example.com\"],\"DelayAfter\":2000,\"DelayBefore\":0}]}]}"
}
```

Here's the subsequent request used to stop the original timeline:
```
{
  "machineId": "22f1a579-27f7-48a7-932e-1dcdd1dc4603",
  "type": 10,
  "activeUtc": "2023-01-11T16:04:57.314Z",
  "createdUtc": "2023-01-11T16:04:57.314Z",
  "update": "{\"Id\":\"b7c3b657-fd29-413c-ad44-3ddc09b4146f\",\"Status\":\"Run\",\"TimeLineHandlers\":[{\"HandlerType\":\"NpcSystem\",\"Initial\":\"\",\"UtcTimeOn\":\"00:00:00\",\"UtcTimeOff\":\"24.00:00:00\",\"Loop\":false,\"TimeLineEvents\":[{\"TrackableId\":null,\"Command\":\"stop\",\"CommandArgs\":[],\"DelayAfter\":0,\"DelayBefore\":0}]}]}"
}
```

With this patch, the BrowserChrome thread exits as expected and stops making requests.