### PR TITLE
Various  updates to V7 code

### DIFF
--- a/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
+++ b/src/Ghosts.Client/Handlers/BaseBrowserHandler.cs
@@ -42,6 +42,9 @@ namespace Ghosts.Client.Handlers
         public string UserAgentString { get; set; }
         PostContentManager _posthelper = null;
 
+
+
+
         private Task LaunchThread(TimelineHandler handler, TimelineEvent timelineEvent, string site)
         {
             var o = new BrowserCrawl();
@@ -98,7 +101,17 @@ namespace Ghosts.Client.Handlers
                                     if (_sharepointhelper == null) sharepointAbort = true;
                                 }
 
-                                if (_sharepointhelper != null) _sharepointhelper.Execute(handler, timelineEvent);
+                                if (_sharepointhelper != null)
+                                {
+                                    _sharepointhelper.Execute(handler, timelineEvent);
+                                    this.Restart = _sharepointhelper.RestartNeeded();
+                                    if (this.Restart)
+                                    {
+                                        _sharepointhelper = null;  //remove the helper
+                                        Log.Trace($"Sharepoint:: Restart requested for {this.BrowserType.ToString()} , restarting...");
+                                        return;  //restart has been requested 
+                                    }
+                                } 
                             }
                             break;
                        case "blog":
@@ -235,56 +248,19 @@ namespace Ghosts.Client.Handlers
             {
                 jitterfactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
             }
+
+
+
         }
 
         public void Upload(TimelineHandler handler, TimelineEvent timelineEvent)
         {
             throw new NotImplementedException();
-            //try
-            //{
-            //    if (Driver.CurrentWindowHandle == null)
-            //    {
-            //        throw new Exception("Browser window handle not available");
-            //    }
-
-            //    var config = RequestConfiguration.Load(handler,
-            //        timelineEvent.CommandArgs[_random.Next(0, timelineEvent.CommandArgs.Count)]);
-
-            //    //var options = new RestClientOptions
-            //    //{
-            //    //    UserAgent = this.UserAgentString
-            //    //};
-            //    //var client = new RestClient(options);
-            //    //var request = new RestRequest(config.Uri, Method.Post)
-            //    //{
-            //    //    Timeout = -1
-            //    //};
-                
-
-            //    //if (config.FormValues == null || string.IsNullOrEmpty(config.FormValues["file"]))
-            //    //{
-            //    //    throw new Exception("Config formValues is malformed");
-            //    //}
-
-            //    //request.AddFile("File", config.FormValues["file"]);
-            //    //var response = client.Execute(request);
-            //    //Report(handler.HandlerType.ToString(), timelineEvent.Command, config.ToString(), timelineEvent.TrackableId, response.Content);
-
-            //    //if (!string.IsNullOrEmpty(timelineEvent.TrackableId) && !string.IsNullOrEmpty(response.Content))
-            //    //{
-            //    //    var tm = new Trackables.TrackablesManager();
-            //    //    tm.Add(new Trackables.Trackable(timelineEvent.TrackableId, response.Content.Replace("\"","")));
-            //    //    tm.Save();
-            //    //}
-            //}
-            //catch(Exception ex)
-            //{
-            //    Log.Trace($"Upload request failed, exiting... {ex}");
-            //}
         }
 
-        public void DoRandomCommand(TimelineHandler handler, TimelineEvent timelineEvent)
+            public void DoRandomCommand(TimelineHandler handler, TimelineEvent timelineEvent)
         {
+            
             this.linkManager = new LinkManager(visitedRemember);
 
             while (true)
@@ -326,7 +302,7 @@ namespace Ghosts.Client.Handlers
 
                                     Log.Trace($"Making request #{loopNumber+1}/{loops} to {config.Uri}");
                                     MakeRequest(config);
-                                    Report(handler.HandlerType.ToString(), timelineEvent.Command, config.ToString(), timelineEvent.TrackableId);
+                                    Report(handler.HandlerType.ToString(), timelineEvent.Command, config.ToString(), timelineEvent.TrackableId);                                 
                                 }
                                 catch (Exception e)
                                 {
@@ -454,8 +430,8 @@ namespace Ghosts.Client.Handlers
 
                 Log.Trace(e.Message);
                 HandleBrowserException(e);
-            }
 
+            }
             return retVal;
         }
 
@@ -722,11 +698,19 @@ namespace Ghosts.Client.Handlers
 
             }
         }
-        
+
+
+
+
+ 
+
         public virtual void HandleBrowserException(Exception e)
         {
+
         }
-        
+
+      
+
         /// <summary>
         /// Close browser
         /// </summary>

--- a/src/Ghosts.Client/Handlers/BrowserChrome.cs
+++ b/src/Ghosts.Client/Handlers/BrowserChrome.cs
@@ -183,7 +183,7 @@ namespace Ghosts.Client.Handlers
                             options.AddArgument($"--user-agent={handler.HandlerArgs["ua-string"]}");
                             break;
                     }
-                    
+
                 }
             }
 
@@ -205,7 +205,13 @@ namespace Ghosts.Client.Handlers
             options.AddUserProfilePreference("download.directory_upgrade", true);
             options.AddUserProfilePreference("plugins.plugins_disabled", "Chrome PDF Viewer");
             options.AddUserProfilePreference("plugins.always_open_pdf_externally", true);
-            options.AddUserProfilePreference("safebrowsing.enabled", "false");  //this stops the confirmation popup when downloading files like .exe, .xml,etc
+
+            //disable keep/discard popup query for files with extensions like .exe
+            options.AddUserProfilePreference("safebrowsing.enabled", true);  //ironically, must be set to true along with the next two options
+            options.AddArguments("--safebrowsing-disable-download-protection");
+            options.AddArguments("--safebrowsing-disable-extension-blacklist");
+
+
 
             if (!string.IsNullOrEmpty(Program.Configuration.ChromeExtensions))
             {

--- a/src/Ghosts.Client/Handlers/SharepointHelper.cs
+++ b/src/Ghosts.Client/Handlers/SharepointHelper.cs
@@ -74,6 +74,7 @@ namespace Ghosts.Client.Handlers
         {
 
             Actions actions;
+            
 
             try
             {
@@ -107,6 +108,7 @@ namespace Ghosts.Client.Handlers
             {
                 Log.Trace($"Sharepoint:: Error performing sharepoint download from site {site}.");
                 Log.Error(e);
+                errorCount += 1;
             }
             return true;
         }
@@ -176,6 +178,7 @@ namespace Ghosts.Client.Handlers
             {
                 Log.Trace($"Sharepoint:: Error performing sharepoint upload to site {site}.");
                 Log.Error(e);
+                errorCount += 1;
             }
             return true;
         }
@@ -217,6 +220,7 @@ namespace Ghosts.Client.Handlers
             {
                 Log.Trace($"Sharepoint:: Error performing sharepoint download from site {site}.");
                 Log.Error(e);
+                errorCount += 1;
             }
             return true;
         }
@@ -237,6 +241,8 @@ namespace Ghosts.Client.Handlers
         private int _downloadProbability = -1;
         private Credentials _credentials = null;
         private string _state = "initial";
+        public int errorCount = 0;
+        public int errorThreshold = 3;  //after three strikes, restart the browser
         public string site { get; set; } = null;
         string username { get; set; } = null;
         string password { get; set; } = null;
@@ -269,6 +275,10 @@ namespace Ghosts.Client.Handlers
             return helper;
         }
 
+        public bool RestartNeeded()
+        {
+            return errorCount > errorThreshold;
+        }
         
 
         public void Init(BaseBrowserHandler callingHandler, IWebDriver currentDriver)

--- a/src/Ghosts.Client/Infrastructure/SftpSupport.cs
+++ b/src/Ghosts.Client/Infrastructure/SftpSupport.cs
@@ -123,7 +123,7 @@ namespace Ghosts.Client.Infrastructure
                 var fname = GetUploadFilename();
                 if (fname == null)
                 {
-                    Log.Trace($"Sft[:: Cannot find a valid file to upload from directory {uploadDirectory}.");
+                    Log.Trace($"Sftp:: Cannot find a valid file to upload from directory {uploadDirectory}.");
                     return null;
                 }
                 currentcmd = currentcmd.Replace("[localfile]", fname);
@@ -157,7 +157,7 @@ namespace Ghosts.Client.Infrastructure
                 fileName = GetUploadFilename();
                 if (fileName == null)
                 {
-                    Log.Trace($"Sft[:: Cannot find a valid file to upload from directory {uploadDirectory}.");
+                    Log.Trace($"Sftp:: Cannot find a valid file to upload from directory {uploadDirectory}.");
                     return;
                 }
             }
@@ -169,7 +169,7 @@ namespace Ghosts.Client.Infrastructure
                     var components = fileName.Split(Path.DirectorySeparatorChar);
                     var remoteFileName = components[components.Length - 1];
                     client.UploadFile(fileStream, remoteFileName, true);
-                    Log.Trace($"Sftp:: Uploaded local file {fileName} to file {remoteFileName}, host {this.HostIp} ");
+                    Log.Trace($"Sftp:: Success, Uploaded local file {fileName} to file {remoteFileName}, host {this.HostIp} ");
                     fileStream.Close();
                 }
             }
@@ -200,7 +200,7 @@ namespace Ghosts.Client.Infrastructure
                 SftpFile file = GetRemoteFile(client);
                 if (file == null)
                 {
-                    Log.Trace($"Sft[:: Cannot find a valid file to delete from remote host {this.HostIp}.");
+                    Log.Trace($"Sftp:: Cannot find a valid file to delete from remote host {this.HostIp}.");
                     return;
                 }
                 fileName = file.FullName;
@@ -210,7 +210,7 @@ namespace Ghosts.Client.Infrastructure
             try
             {
                 client.DeleteFile(fileName);
-                Log.Trace($"Sftp:: Deleted {fileName} on remote host {this.HostIp}.");
+                Log.Trace($"Sftp:: Success, Deleted {fileName} on remote host {this.HostIp}.");
             }
             catch (Exception e)
             {
@@ -240,7 +240,7 @@ namespace Ghosts.Client.Infrastructure
                 SftpFile file = GetRemoteFile(client);
                 if (file == null)
                 {
-                    Log.Trace($"Sft[:: Cannot find a valid file to download from remote host {this.HostIp}.");
+                    Log.Trace($"Sftp:: Cannot find a valid file to download from remote host {this.HostIp}.");
                     return;
                 }
                 remoteFilePath = file.FullName;
@@ -291,7 +291,7 @@ namespace Ghosts.Client.Infrastructure
                 using (var fileStream = System.IO.File.OpenWrite(localFilePath))
                 {
                     client.DownloadFile(remoteFilePath, fileStream);
-                    Log.Trace($"Sftp:: Downloaded remote file {remoteFilePath},host {this.HostIp}  to file {localFilePath},  ");
+                    Log.Trace($"Sftp:: Success, Downloaded remote file {remoteFilePath},host {this.HostIp}  to file {localFilePath},  ");
                     fileStream.Close();
                 }
             }
@@ -316,7 +316,7 @@ namespace Ghosts.Client.Infrastructure
                 SftpFile file = GetRemoteDir(client);
                 if (file == null)
                 {
-                    Log.Trace($"Sft[:: Cannot find a valid directory to change to on remote host {this.HostIp}.");
+                    Log.Trace($"Sftp:: Cannot find a valid directory to change to on remote host {this.HostIp}.");
                     return;
                 }
                 dirName = file.FullName;
@@ -325,7 +325,7 @@ namespace Ghosts.Client.Infrastructure
             try
             {
                 client.ChangeDirectory(dirName);
-                Log.Trace($"Sftp:: Changed to directory {dirName} on remote host {this.HostIp}.");
+                Log.Trace($"Sftp:: Success, Changed to directory {dirName} on remote host {this.HostIp}.");
             }
             catch (Exception e)
             {
@@ -354,7 +354,7 @@ namespace Ghosts.Client.Infrastructure
                 if (FindDir(client, dirName) == null)
                 {
                     client.CreateDirectory(dirName);
-                    Log.Trace($"Sftp:: Created directory {dirName} on remote host {this.HostIp}.");
+                    Log.Trace($"Sftp:: Success, Created directory {dirName} on remote host {this.HostIp}.");
                 } else
                 {
                     Log.Trace($"Sftp:: mkdir directory command skipped, as {dirName} already exists remote host {this.HostIp}.");
@@ -388,7 +388,7 @@ namespace Ghosts.Client.Infrastructure
             try
             {
                 var remoteFiles = client.ListDirectory(dirName).ToList<SftpFile>();
-                Log.Trace($"Sftp::Found {remoteFiles.Count} in directory {dirName} on remote host {this.HostIp}.");
+                Log.Trace($"Sftp:: Success, Found {remoteFiles.Count} in directory {dirName} on remote host {this.HostIp}.");
             }
             catch (Exception e)
             {

--- a/src/Ghosts.Client/Infrastructure/SshSupport.cs
+++ b/src/Ghosts.Client/Infrastructure/SshSupport.cs
@@ -147,7 +147,9 @@ namespace Ghosts.Client.Infrastructure
             if (newcmd != null)
             {
                 client.WriteLine(newcmd);  //write command to client
-                return this.GetSshCommandOutput(client, false);
+                string result = this.GetSshCommandOutput(client, false);
+                Log.Trace($"SSH: Success, executed command: {newcmd} on remote host: {HostIp}");
+                return result;
             }
             else
             {

--- a/src/Ghosts.Client/Infrastructure/WmiSupport.cs
+++ b/src/Ghosts.Client/Infrastructure/WmiSupport.cs
@@ -180,6 +180,7 @@ namespace Ghosts.Client.Infrastructure
                         instance.CimInstanceProperties["InstallDate"].Value
                     );
                 }
+                Log.Trace($"Wmi:: Success, Cmd: GetOperatingSystem, remote host: {_computerName}");
             }
             catch (CimException ex)
             {
@@ -209,6 +210,7 @@ namespace Ghosts.Client.Infrastructure
                         return;
                     }
                 }
+                Log.Trace($"Wmi:: Success, Cmd: GetBios, remote host: {_computerName}");
             }
             catch (CimException ex)
             {
@@ -243,6 +245,7 @@ namespace Ghosts.Client.Infrastructure
                         ProcessorList.Add(instance.CimInstanceProperties["Manufacturer"].Value);
                     }
                 }
+                Log.Trace($"Wmi:: Success, Cmd: GetProcessor, remote host: {_computerName}");
                 return;
             }
             catch (CimException ex)
@@ -274,6 +277,7 @@ namespace Ghosts.Client.Infrastructure
                         UserList.Add(instance.CimInstanceProperties["Name"].Value);
                     }
                 }
+                Log.Trace($"Wmi:: Success, Cmd: GetUserList, remote host: {_computerName}");
                 return;
             }
             catch (CimException ex)
@@ -321,6 +325,7 @@ namespace Ghosts.Client.Infrastructure
                         );
                     }
                 }
+                Log.Trace($"Wmi:: Success, Cmd: GetNetworkInfo, remote host: {_computerName}");
                 return;
             }
             catch (CimException ex)
@@ -356,6 +361,7 @@ namespace Ghosts.Client.Infrastructure
                         );
                     }
                 }
+                Log.Trace($"Wmi:: Success, Cmd: GetFilesList, remote host: {_computerName}");
                 return;
             }
             catch (CimException ex)
@@ -396,6 +402,7 @@ namespace Ghosts.Client.Infrastructure
                         );
                     }
                 }
+                Log.Trace($"Wmi:: Success, Cmd: GetProcessList, remote host: {_computerName}");
                 return;
             }
             catch (CimException ex)


### PR DESCRIPTION
Synched with V7 code, added misc updates that were done over the last month.

Changes are:
 Sharepoint helper now restarts if too many errors are detected trying to make it work better with Chrome. However, bottom line determination is that Sharepoint 2013 does not play well with Chrome, only Firefox.
 Some changes  made to BrowserChrome to try to get rid of file download confirmations.
 Log message cleanup/changes to SFTP, SSH, WMI, SharepointHelper to make it easier to determine success/fail of operations based on log file parsing.
 Orchestrator changed so that if a 'stop.txt' file is written to config directory, GHOSTS exits. This was requested by our event engineers.