### PR TITLE
Sharepoint helper fix for special chars in user/password

### DIFF
--- a/src/Ghosts.Client/Handlers/BrowserChrome.cs
+++ b/src/Ghosts.Client/Handlers/BrowserChrome.cs
@@ -55,7 +55,10 @@ namespace Ghosts.Client.Handlers
 
                     try
                     {
-                        this.UserAgentString = JS.ExecuteScript("return navigator.userAgent").ToString();
+                        if (JS != null)
+                        {
+                            this.UserAgentString = JS.ExecuteScript("return navigator.userAgent").ToString();
+                        }
                     }
                     catch
                     {

--- a/src/Ghosts.Client/Handlers/BrowserFirefox.cs
+++ b/src/Ghosts.Client/Handlers/BrowserFirefox.cs
@@ -138,7 +138,10 @@ namespace Ghosts.Client.Handlers
 
                     try
                     {
-                        this.UserAgentString = JS.ExecuteScript("return navigator.userAgent").ToString();
+                        if (JS != null)
+                        {
+                            this.UserAgentString = JS.ExecuteScript("return navigator.userAgent").ToString();
+                        }
                     }
                     catch
                     {

--- a/src/Ghosts.Client/Handlers/SharepointHelper.cs
+++ b/src/Ghosts.Client/Handlers/SharepointHelper.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Actions = OpenQA.Selenium.Interactions.Actions;
 using Exception = System.Exception;
 using NLog;
+using System.Web;
 
 namespace Ghosts.Client.Handlers
 {
@@ -35,7 +36,9 @@ namespace Ghosts.Client.Handlers
 
             string portal = site;
 
-            string target = header + user + ":" + pw + "@" + portal + "/";
+            var pw_encoded = HttpUtility.UrlEncode(pw);
+            var user_encoded = HttpUtility.UrlEncode(user); 
+            string target = header + user_encoded + ":" + pw_encoded + "@" + portal + "/";
             config = RequestConfiguration.Load(handler, target);
             try
             {


### PR DESCRIPTION
Fixed sharepoint helper to URL encode user/pw before using in the sharepoint URL to fix problem with special characters.
Changed Chrome/Firefox handlers to check if JS is non-null before executing Javascript.

WARNING: This fix requires that a reference to System.Web be added to the Ghosts Client project.


