### PR TITLE
Outlookv2

### DIFF
--- a/src/Ghosts.Client/Handlers/Outlookv2.cs
+++ b/src/Ghosts.Client/Handlers/Outlookv2.cs
@@ -1,0 +1,677 @@
+﻿// Copyright 2017 Carnegie Mellon University. All Rights Reserved. See LICENSE.md file for terms.
+
+using Ghosts.Client.Infrastructure.Email;
+using Ghosts.Domain;
+using Ghosts.Domain.Code;
+using Microsoft.Office.Interop.Outlook;
+using Redemption;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Ghosts.Domain.Code.Helpers;
+using Exception = System.Exception;
+using MAPIFolder = Microsoft.Office.Interop.Outlook.MAPIFolder;
+
+namespace Ghosts.Client.Handlers;
+
+public class Outlookv2 : BaseHandler
+{
+    private readonly Application _app;
+    private readonly NameSpace _oMapiNamespace;
+    private readonly MAPIFolder _folderOutbox;
+    private readonly MAPIFolder _folderInbox;
+    
+
+    //primary actions - delete, send, reply, read
+    private int _deleteProbability = 25;  //cleanup email
+    private int _createProbability = 25;    //create new email
+    private int _replyProbability = 25;     //reply to existing email
+    private int _readProbability = 25;      //read an unread email
+
+    //additional actions
+    private int _uploadProbability = 0;   //when creating, probability to add an attachment
+    private int _downloadProbability = 0; //when reading, probability to download an attachment
+    private int _clickProbability = 0;   //when reading, probability to click on a link
+
+    private string _uploadDirectory = null;
+    private string _downloadDirectory = null;
+    private int _jitterfactor = 0;  //used with Jitter.JitterFactorDelay
+
+    private string[] _actionList = { "read", "reply", "create", "delete" };
+    private int[] _probabilityList = { 0, 0, 0, 0 };
+
+    public Outlookv2(TimelineHandler handler)
+    {
+        try
+        {
+            base.Init(handler);
+            //redemption prep
+            //tell the app where the 32 and 64 bit dlls are located
+            //by default, they are assumed to be in the same folder as the current assembly and be named
+            //Redemption.dll and Redemption64.dll.
+            //In that case, you do not need to set the two properties below
+            var currentDir = new FileInfo(GetType().Assembly.Location).Directory;
+            RedemptionLoader.DllLocation64Bit = Path.GetFullPath(currentDir + @"\lib\redemption64.dll");
+            RedemptionLoader.DllLocation32Bit = Path.GetFullPath(currentDir + @"\lib\redemption.dll");
+            //Create a Redemption object and use it
+            Log.Trace("Creating new RDO session");
+            var session = RedemptionLoader.new_RDOSession();
+            Log.Trace("Attempting RDO session logon...");
+            session.Logon(Missing.Value, Missing.Value, Missing.Value, Missing.Value, Missing.Value, Missing.Value);
+        }
+        catch (Exception e)
+        {
+            Log.Error($"RDO load error: {e}");
+        }
+
+        try
+        {
+            _app = new Application();
+            _oMapiNamespace = _app.GetNamespace("MAPI");
+            _folderInbox = _oMapiNamespace.GetDefaultFolder(OlDefaultFolders.olFolderInbox);
+            _folderOutbox = _oMapiNamespace.GetDefaultFolder(OlDefaultFolders.olFolderOutbox);
+            Log.Trace("Launching Outlook");
+            _folderInbox.Display();
+
+            //TODO: Add parsing of handler args
+
+            _probabilityList[0] = _readProbability;
+            _probabilityList[1] = _replyProbability;
+            _probabilityList[2] = _createProbability;
+            _probabilityList[3] = _deleteProbability;
+            
+            
+
+            if (handler.Loop)
+            {
+                while (true)
+                {
+                    ExecuteEvents(handler);
+                }
+            }
+            else
+            {
+                ExecuteEvents(handler);
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+        }
+    }
+
+    public void ExecuteEvents(TimelineHandler handler)
+    {
+        try
+        {
+            foreach (var timelineEvent in handler.TimeLineEvents)
+            {
+                var action = SelectActionFromProbabilities(_probabilityList, _actionList);
+                if (action == null)
+                {
+                    Log.Trace("Outlookv2:: No action this cycle.");
+                }
+                else
+                {
+                    Infrastructure.WorkingHours.Is(handler);
+
+
+                    if (timelineEvent.DelayBefore > 0)
+                    {
+                        Log.Trace($"DelayBefore sleeping for {timelineEvent.DelayBefore} ms");
+                        Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayBefore, _jitterfactor));
+                    }
+
+                    Log.Trace($"Outlookv2:: Performing action {action} .");
+
+                    switch (action)
+                    {
+                        case "create":
+                            try
+                            {
+                                var emailConfig = new EmailConfiguration(timelineEvent.CommandArgs);
+                                if (SendEmailViaOutlook(emailConfig))
+                                {
+                                    Report(handler.HandlerType.ToString(), timelineEvent.Command, emailConfig.ToString());
+                                    Log.Trace("Outlookv2:: Created email");
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(e);
+                            }
+
+                            break;
+                        case "reply":
+                            try
+                            {
+                                var emailConfig = new EmailConfiguration(timelineEvent.CommandArgs);
+                                if (ReplyViaOutlook(emailConfig))
+                                {
+                                    Report(handler.HandlerType.ToString(), timelineEvent.Command, emailConfig.ToString());
+                                    Log.Trace("Outlookv2:: Replied email");
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(e);
+                            }
+                            break;
+                        case "read":
+                            try
+                            {
+                                if (ReadViaOutlook())
+                                {
+                                    Log.Trace("Outlookv2:: Read email");
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(e);
+                            }
+                            break;
+                        case "delete":
+                            try
+                            {
+                                if (DeleteViaOutlook())
+                                {
+                                    Log.Trace("Outlookv2:: Deleted email");
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(e);
+                            }
+                            break;
+
+                    }
+
+                    if (timelineEvent.DelayAfter > 0)
+                    {
+                        Log.Trace($"DelayAfter sleeping for {timelineEvent.DelayAfter} ms");
+                        Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayAfter, _jitterfactor));
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+        }
+    }
+
+    private void CleanFolder(string targetFolderName, bool deleteAll, bool deleteUnread)
+    {
+        var folderName = GetFolder(targetFolderName);
+        var targetFolder = this._app.Session.GetDefaultFolder(folderName);
+
+        var folderItems = targetFolder.Items;
+        var count = folderItems.Count;
+        var settings = Program.Configuration.Email;
+
+        if (!deleteAll && count <= settings.EmailsMax)
+        {
+            return; //nothing to do
+        }
+        
+        foreach (MailItem folderItem in folderItems)
+        {
+            if (deleteAll)
+            {
+                folderItem.Delete();
+            }
+            else
+            {
+                if (folderItem.UnRead && !deleteUnread) continue;
+                folderItem.Delete();
+                count = count - 1;
+                if (count <= settings.EmailsMax)
+                {
+                    break;
+                }
+            }
+
+        }
+    }
+
+
+    private bool DeleteViaOutlook()
+    {
+        try
+        {
+            
+            var settings = Program.Configuration.Email;
+
+            if (settings.EmailsMax <= 0)
+            {
+                Log.Trace("Outlookv2: EmailsMax in application.json must be set greater than 0 for cleanup/deletion operation to occur.");
+                return true;
+            }
+
+            CleanFolder("INBOX", false, false);
+            CleanFolder("INBOX", false, true);
+            CleanFolder("SENT", false, true);
+            CleanFolder("DELETED", true, true);
+
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool ReadViaOutlook()
+    {
+        try
+        {
+            var folderItems = _folderInbox.Items;
+
+            foreach (MailItem folderItem in folderItems)
+            {
+                if (!folderItem.UnRead) continue;
+                // mark as read
+                folderItem.UnRead = false;
+                folderItem.Display(false);
+                Thread.Sleep(10000);
+                folderItem.Close(Microsoft.Office.Interop.Outlook.OlInspectorClose.olDiscard);
+                return true;
+            }
+            //if get here, read an email already read
+            var choice = _random.Next(0, folderItems.Count - 1);
+            var index = 0;
+            foreach (MailItem folderItem in folderItems)
+            {
+                if (index == choice)
+                {
+                    folderItem.Display(false);
+                    Thread.Sleep(10000);
+                    folderItem.Close(Microsoft.Office.Interop.Outlook.OlInspectorClose.olDiscard);
+                    break;
+                }
+                index += 1;
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+            return false;
+        }
+
+        return true;
+    }
+
+
+    private bool ClickRandomLink(TimelineEvent timelineEvent)
+    {
+        try
+        {
+            var folderItemsRaw = _folderInbox.Items;
+            var folderItems = new List<MailItem>();
+            foreach (MailItem folderItem in folderItemsRaw)
+            {
+                folderItems.Add(folderItem);
+            }
+
+            var filteredEmails = folderItems.Where(x => x.BodyFormat == OlBodyFormat.olFormatHTML && x.HTMLBody.Contains("<a href="));
+            var mailItem = filteredEmails.PickRandom();
+
+            //check deny list
+            var list = DenyListManager.ScrubList(mailItem.HTMLBody.GetHrefUrls());
+            if (list.Any())
+            {
+                list.PickRandom().OpenUrl();
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool Navigate(IEnumerable<object> config)
+    {
+        var hasErrors = true;
+
+        try
+        {
+            foreach (var configuredFolder in config)
+            {
+                try
+                {
+                    var fName = configuredFolder.ToString();
+                    var sleepTime = 5000;
+
+                    var configArray = fName.Split(Convert.ToChar("|"));
+                    if (configArray.GetUpperBound(0) > 0)
+                    {
+                        try
+                        {
+                            fName = configArray[0].Trim();
+                            sleepTime = Convert.ToInt32(configArray[1].Trim()) * 1000;
+                        }
+                        catch
+                        {
+                            //
+                        }
+                    }
+
+                    var folderName = GetFolder(fName);
+                    var f = this._app.Session.GetDefaultFolder(folderName);
+                    f.Display();
+                    Log.Trace($"Folder displayed: {folderName} - now sleeping for {sleepTime}");
+                    Thread.Sleep(sleepTime);
+                }
+                catch (Exception e)
+                {
+                    Log.Debug($"Could not navigate to folder: {configuredFolder}: {e}");
+                }
+                this.CloseExplorers();
+            }
+        }
+        catch (Exception exc)
+        {
+            Log.Debug(exc);
+            hasErrors = false;
+        }
+        return hasErrors;
+    }
+
+    private OlDefaultFolders GetFolder(string folder)
+    {
+        Log.Trace(folder.ToUpper());
+        switch (folder.ToUpper())
+        {
+            default:
+                return OlDefaultFolders.olFolderInbox;
+            case "OUTBOX":
+                return OlDefaultFolders.olFolderOutbox;
+            case "DRAFTS":
+                return OlDefaultFolders.olFolderDrafts;
+            case "SENT":
+                return OlDefaultFolders.olFolderSentMail;
+            case "DELETED":
+            case "DELETEDITEMS":
+                return OlDefaultFolders.olFolderDeletedItems;
+            case "JUNK":
+                return OlDefaultFolders.olFolderJunk;
+        }
+    }
+
+    private void CloseExplorers()
+    {
+        var explorerCount = this._app.Explorers.Count;
+        Log.Trace($"Explorer count: {explorerCount}");
+        if (explorerCount > 0)
+        {
+            //# MS Program APIs are 1-indexed.
+            for (var i = 1; i < explorerCount + 1; i++)
+            {
+                try
+                {
+                    this._app.Explorers[i].Close();
+                    Log.Trace($"Closing app explorer: {i}");
+                }
+                catch (Exception exc)
+                {
+                    Log.Trace($"Error in closing app explorer: {exc}");
+                }
+            }
+        }
+    }
+
+    // ReSharper disable once UnusedParameter.Local
+    private bool ReplyViaOutlook(EmailConfiguration emailConfig)
+    {
+        var config = Program.Configuration.Email;
+
+        try
+        {
+            var folderItems = _folderInbox.Items;
+
+            foreach (MailItem folderItem in folderItems)
+            {
+                if (!folderItem.UnRead) continue;
+
+                var emailReply = new EmailReplyManager();
+
+                var replyMail = folderItem.Reply();
+
+                using (var quoted = new StringWriter())
+                {
+                    quoted.WriteLine(emailReply.Reply);
+                    quoted.WriteLine("");
+                    quoted.WriteLine("");
+                    quoted.WriteLine($"On {folderItem.SentOn:f}, {folderItem.SenderEmailAddress} wrote:");
+                    using (var reader = new StringReader(folderItem.Body))
+                    {
+                        string line;
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            quoted.Write("> ");
+                            quoted.WriteLine(line);
+                        }
+                    }
+
+                    replyMail.Body = quoted.ToString();
+                }
+
+                replyMail.Subject = $"RE: {folderItem.Subject}";
+
+                var rdoMail = new SafeMailItem
+                {
+                    Item = replyMail
+                };
+
+                var r = rdoMail.Recipients.AddEx(folderItem.SenderEmailAddress);
+                r.Resolve();
+                rdoMail.Recipients.ResolveAll();
+                rdoMail.Send();
+
+                var mapiUtils = new MAPIUtils();
+                mapiUtils.DeliverNow();
+
+                // mark as read
+                folderItem.UnRead = false;
+
+                if (config.SetForcedSendReceive)
+                {
+                    Log.Trace("Forcing mapi - send and receive, then sleeping for 3000");
+                    _oMapiNamespace.SendAndReceive(false);
+                    Thread.Sleep(3000);
+                }
+
+                return true;
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Outlook reply error: {e}");
+        }
+        return false;
+    }
+
+    private bool SendEmailViaOutlook(EmailConfiguration emailConfig)
+    {
+        ClientConfiguration.EmailSettings config = Program.Configuration.Email;
+        bool wasSuccessful = false;
+
+        try
+        {
+            //now create mail object (but we'll not send it via outlook)
+            Log.Trace("Creating outlook mail item");
+            dynamic mailItem = _app.CreateItem(OlItemType.olMailItem);
+
+            //Add subject
+            if (!string.IsNullOrWhiteSpace(emailConfig.Subject))
+            {
+                mailItem.Subject = emailConfig.Subject;
+            }
+
+            Log.Trace($"Setting message subject to: {mailItem.Subject}");
+
+            //Set message body according to type of message
+            switch (emailConfig.BodyType)
+            {
+                case EmailConfiguration.EmailBodyType.HTML:
+                    mailItem.HTMLBody = emailConfig.Body;
+                    Log.Trace($"Setting message HTMLBody to: {emailConfig.Body}");
+                    break;
+                case EmailConfiguration.EmailBodyType.RTF:
+                    mailItem.RTFBody = emailConfig.Body;
+                    Log.Trace($"Setting message RTFBody to: {emailConfig.Body}");
+                    break;
+                case EmailConfiguration.EmailBodyType.PlainText:
+                    mailItem.Body = emailConfig.Body;
+                    Log.Trace($"Setting message Body to: {emailConfig.Body}");
+                    break;
+                default:
+                    throw new Exception("Bad email body type: " + emailConfig.BodyType);
+            }
+
+            //attachments
+            if (emailConfig.Attachments.Count > 0)
+            {
+                //Add attachments
+                foreach (string path in emailConfig.Attachments)
+                {
+                    mailItem.Attachments.Add(path);
+                    Log.Trace($"Adding attachment from: {path}");
+                }
+            }
+
+            if (config.SetAccountFromConfig || config.SetAccountFromLocal)
+            {
+                Accounts accounts = _app.Session.Accounts;
+                Account acc = null;
+
+                if (config.SetAccountFromConfig)
+                {
+                    //Look for our account in the Outlook
+                    foreach (Account account in accounts)
+                    {
+                        if (account.SmtpAddress.Equals(emailConfig.From, StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            //Use it
+                            acc = account;
+                            break;
+                        }
+                    }
+                }
+
+                if (acc == null)
+                {
+                    foreach (Account account in accounts)
+                    {
+                        acc = account;
+                        break;
+                    }
+                }
+
+                //Did we get the account?
+                if (acc != null)
+                {
+                    Log.Trace($"Sending via {acc.DisplayName}");
+                    //Use this account to send the e-mail
+                    mailItem.SendUsingAccount = acc;
+                }
+            }
+
+            if (config.SaveToOutbox)
+            {
+                Log.Trace("Saving mailItem to outbox...");
+                mailItem.Move(_folderOutbox);
+                mailItem.Save();
+            }
+
+            Log.Trace("Attempting new Redemtion SafeMailItem...");
+            var rdoMail = new SafeMailItem
+            {
+                Item = mailItem
+            };
+
+            //Parse To
+            if (emailConfig.To.Count > 0)
+            {
+                var list = emailConfig.To.Distinct();
+                foreach (var a in list)
+                {
+                    var r = rdoMail.Recipients.AddEx(a.Trim());
+                    r.Resolve();
+                    Log.Trace($"RdoMail TO {a.Trim()}");
+                }
+            }
+            else
+            {
+                throw new Exception("Must specify to-address");
+            }
+
+            //Parse Cc
+            if (emailConfig.Cc.Count > 0)
+            {
+                var list = emailConfig.Cc.Distinct();
+                foreach (var a in list)
+                {
+                    var r = rdoMail.Recipients.AddEx(a.Trim());
+                    r.Resolve();
+                    if (r.Resolved)
+                    {
+                        r.Type = 2; //CC
+                    }
+
+                    Log.Trace($"RdoMail CC {a.Trim()}");
+                }
+            }
+
+            if (emailConfig.Bcc.Count > 0)
+            {
+                var list = emailConfig.Bcc.Distinct();
+                foreach (var a in list)
+                {
+                    var r = rdoMail.Recipients.AddEx(a.Trim());
+                    r.Resolve();
+                    if (r.Resolved)
+                    {
+                        r.Type = 3; //BCC
+                    }
+
+                    Log.Trace($"RdoMail BCC {a.Trim()}");
+                }
+            }
+
+            rdoMail.Recipients.ResolveAll();
+
+            Log.Trace("Attempting to send Redemtion SafeMailItem...");
+            rdoMail.Send();
+
+            var mapiUtils = new MAPIUtils();
+            mapiUtils.DeliverNow();
+
+            //Done
+            wasSuccessful = true;
+
+            Log.Trace("Redemtion SafeMailItem was sent successfully");
+
+            if (config.SetForcedSendReceive)
+            {
+                Log.Trace("Forcing mapi - send and receive, then sleeping for 3000");
+                _oMapiNamespace.SendAndReceive(false);
+                Thread.Sleep(3000);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+        Log.Trace($"Returning - wasSuccessful:{wasSuccessful}");
+        return wasSuccessful;
+    }
+}

--- a/src/Ghosts.Client/Infrastructure/CronScheduling.cs
+++ b/src/Ghosts.Client/Infrastructure/CronScheduling.cs
@@ -66,7 +66,7 @@ namespace Ghosts.Client.Infrastructure
                         var orchestrator = new Orchestrator();
                         orchestrator.RunCommandCron(timeline, handler);
                     }
-                    catch (Exception e)
+                    catch
                     {
                         _log.Trace("could not schedule cron job, deserialization failed");
                     }

--- a/src/Ghosts.Client/Sample Timelines/Outlookv2.json
+++ b/src/Ghosts.Client/Sample Timelines/Outlookv2.json
@@ -1,0 +1,63 @@
+/*
+
+  This Outlook handler relies on HandlerArgs probabilities to perform timeline events.
+  The commmand args are used for formatting emails, the probabilities decide the email action.
+  Delete + Create + Read + Reply <= 100
+  For the delete operation, the application.json file should have a "EmailsMax" field that
+  specifies that maximum number of Emails to keep in the Inbox, Sent Items folder.
+  When a delete operation is done, the Inbox, Sent Items folders are pruned to this amount,
+  and all emails in the Deleted Items folder are deleted.
+
+  
+  */
+
+
+
+{
+  "Id": "c5d8bfb6-488a-4d9f-9a84-657769d83e8c",
+  "Status": "Run",
+  "TimeLineHandlers": [
+
+    {
+      "HandlerType": "Outlookv2",
+      "Initial": "",
+      "UtcTimeOn": "00:00:00",
+      "UtcTimeOff": "24.00:00:00",
+      "HandlerArgs": {
+        "delay-jitter": 50, //%jitter to add to delayAfter, delayBefore
+        "delete-probability": 0, //probability that a delete operation will be done
+        "create-probability": 0, //probability that a new email will be created
+        "read-probability": 100, //probability that an existing email will be read, unread is given preference
+        "reply-probability": 0, //probability that a reply to an existing email is created
+        "click-probability": 35, //TODO, not implemented yet
+        "attachment-probability": 100, //when creating a new email, probability that attachments are added
+        "save-attachment-probability": 100, //when reading a email, probability that emails are saved to disk
+        "min-attachments": 5, //when adding an attachment, min number of attachments
+        "max-attachments": 5, //when adding an attachment, max number of attachments
+        "input-directory": "C:\\ghosts_data\\uploads", // source directory for attachments
+        "output-directory": "C:\\ghosts_data\\downloads" // target directory for saved attachments, created if does not exist
+      },
+      "Loop": true,
+      "TimeLineEvents": [
+        {
+          "TrackableId": null,
+          "Command": "",
+          "CommandArgs": [
+            "CurrentUser",
+            "random",
+            "random",
+            "random",
+            "Random",
+            "Random",
+            "PlainText",
+            ""
+          ],
+          "DelayAfter": 10000,
+          "DelayBefore": 0
+        }
+      ]
+    }
+
+
+  ]
+}

--- a/src/Ghosts.Client/TimelineManager/Orchestrator.cs
+++ b/src/Ghosts.Client/TimelineManager/Orchestrator.cs
@@ -428,8 +428,14 @@ namespace Ghosts.Client.TimelineManager
                             _ = new Outlook(handler);
                         });
                         break;
+                    case HandlerType.Outlookv2:
+                        _log.Trace("Launching thread for outlookv2 - note we're not checking if outlook installed, just going for it");
+                        t = new Thread(() =>
+                        {
+                            _ = new Outlookv2(handler);
+                        });
+                        break;
                     case HandlerType.Notepad:
-                        //TODO
                         t = new Thread(() =>
                         {
                             _ = new Notepad(handler);

--- a/src/Ghosts.Client/config/application.json
+++ b/src/Ghosts.Client/config/application.json
@@ -27,6 +27,7 @@
     "PostUrl": "http://ghosts-api:52388/api/clientsurvey"
   },
   "Content": {
+    "EmailsMax":  20,
     "EmailContent": "",
     "EmailReply": "",
     "EmailDomain": "",

--- a/src/Ghosts.Domain/Code/ClientConfiguration.cs
+++ b/src/Ghosts.Domain/Code/ClientConfiguration.cs
@@ -183,6 +183,7 @@ namespace Ghosts.Domain.Code
             public int RecipientsOutsideMin { get; set; }
             public int RecipientsOutsideMax { get; set; }
             public string EmailDomainSearchString { get; set; }
+            public int EmailsMax { get; set; }
         }
 
         public class ListenerSettings

--- a/src/Ghosts.Domain/Messages/Timeline.cs
+++ b/src/Ghosts.Domain/Messages/Timeline.cs
@@ -109,6 +109,7 @@ namespace Ghosts.Domain
         Pidgin = 102,
         Rdp = 103,
         Wmi = 104,
+        Outlookv2 = 105,
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request does the following:

  1. Adds a new handler (Handlers/Outlookv2.cs) that does email actions based on probabilities.  See the sample timeline for this. This is the email handler that we are using for our email traffic gen.
 
  2. Removed AutoIt usage from Pidgin as it causes Outlook problems and replaced all usages with Windows Sendkeys, as we saw the Outlook thread would immediately bomb  once Pidgin started. However, running the Pidgin handler with Office (2013, 2019, 2021) for  a few hours still causes Outlook to lock up, and we traced it to the use of Sendkeys.    For some reason, on VMware VMs, this combination causes instability. So, Pidgin is fine, as long as you don't run it with the Outlook handler.

 3. Removed all usages of AutoIt and Windows Sendkeys from the Notepad handler because of the above clashes with Outlook. This also meant removing the PDF generation capability that was in there. Now the Notepad handler just generates random text files.

This pull request DOES NOT include the project files as our project files have diverged.  To include this pull request, the Handlers/Outlookv2.cs  file and the Sample Timelines/Outlookv2.json will have to be added to your GHOSTS client project file.

This will be the last pull request for a new feature for a while. We are happy with GHOSTS capabilities at the moment and are concentrating on deployment, testing.  We have deployed GHOSTS in an active event, and are planning on including it all future events.

