### PR TITLE
Add insecure certificates option to chrome/firefox

### DIFF
--- a/src/Ghosts.Client/Handlers/BrowserChrome.cs
+++ b/src/Ghosts.Client/Handlers/BrowserChrome.cs
@@ -186,7 +186,11 @@ namespace Ghosts.Client.Handlers
                             options.AddArgument($"--user-agent={handler.HandlerArgs["ua-string"]}");
                             break;
                     }
+                }
 
+                if (handler.HandlerArgs.ContainsKeyWithOption("accept-insecure-certificates", "true"))
+                {
+                    options.AddArguments("ignore-certificate-errors")
                 }
             }
 

--- a/src/Ghosts.Client/Handlers/BrowserFirefox.cs
+++ b/src/Ghosts.Client/Handlers/BrowserFirefox.cs
@@ -280,7 +280,12 @@ namespace Ghosts.Client.Handlers
                     }
 
                 }
-            }
+
+                if (handler.HandlerArgs.ContainsKeyWithOption("accept-insecure-certificates", "true"))
+                {
+                    options.AcceptInsecureCertificates = true;
+                }
+
 
             options.SetPreference("permissions.default.cookies", 2);
             options.SetPreference("permissions.default.popups", 2);


### PR DESCRIPTION
We use GHOSTS within an environment that emulates TLS-equipped websites, however they are secured by an internal/self-signed CA. This PR adds an option to the browser drivers to accept insecure/self-signed certificates.