### PR TITLE
made RDP handler use username from credentials if supplied

### DIFF
--- a/src/Ghosts.Client/Sample Timelines/Rdp.json
+++ b/src/Ghosts.Client/Sample Timelines/Rdp.json
@@ -2,8 +2,8 @@
 /// Each CommandArg is of the form shown below, if multiple CommandArgs are present a random one is chosen for execution on each cycle.
 ///  <targetIp>|<credkey>  The targetIP is the IP to use for the RDP connection
 /// The <credKey> is only used to retrieve the password of the matching record in the credentials file.
-/// The username is ignored as it assumed to be the password of the current logged in user.
-/// The password is supplied if a password  prompt appears on RDP open
+/// The username (if supplied) is  used instead of the logged-in user (can also provide 'domain' keyword in credentials)
+/// The password is used if a password  prompt appears on RDP open
 ///
 
 


### PR DESCRIPTION
Sorry for the back-to-back pull requests.
This PR has the following Remote Desktop handler mods:

-  Initial login is more robust if the login target is slow to respond
-  A 'username' (and optionally a 'domain') can now be supplied for a credential - if supplied, this is used instead of the logged-in user. This enables use of the domain admin as the credential which does not require domain policy modification for  an RDP session.

