### PR TITLE
Fixed bug in outlookv2 in reading email

### DIFF
--- a/src/Ghosts.Client/Handlers/Outlookv2.cs
+++ b/src/Ghosts.Client/Handlers/Outlookv2.cs
@@ -713,7 +713,7 @@ public class Outlookv2 : BaseHandler
     {
         try
         {
-            var folderItems = _folderInbox.Items;
+            var folderItems = _folderInbox.Items.Restrict("[Unread]=true");
             MailItem folderItem;
 
             foreach (object item in folderItems)
@@ -722,6 +722,7 @@ public class Outlookv2 : BaseHandler
                 {
                     folderItem = item as MailItem;
                     if (folderItem == null) continue;
+                    if (!folderItem.UnRead) continue;  //should not be needed but WTH
                     // mark as read
                     folderItem.UnRead = false;
                     folderItem.Display(false);
@@ -741,22 +742,18 @@ public class Outlookv2 : BaseHandler
             var count = folderItems.Count;
             var choice = _random.Next(1, count);
             //if get here, read an email already read
-            for (int i = count; i > 0; i--)
+            for (int i = choice; i > 0; i--)
             {
                 object item = folderItems[i];
                 try
                 {
                     folderItem = item as MailItem;
                     if (folderItem == null) continue;
-                    if (choice <= i)
-                    {
-                        folderItem.Display(false);
-                        DownloadAttachments(folderItem);
-                        Thread.Sleep(10000);
-                        folderItem.Close(Microsoft.Office.Interop.Outlook.OlInspectorClose.olDiscard);
-                        return true;
-                    }
-                    
+                    folderItem.Display(false);
+                    DownloadAttachments(folderItem);
+                    Thread.Sleep(10000);
+                    folderItem.Close(Microsoft.Office.Interop.Outlook.OlInspectorClose.olDiscard);
+                    return true; 
                 }
                 catch (ThreadAbortException)
                 {


### PR DESCRIPTION
This fixes the bug reported in issue #215 about OutlookV2 handler email read always reading the same email and not prioritizing unread emails.  Not sure what I was thinking when I tested this code originally.

