### PR TITLE
Bugfix apr2024

### DIFF
--- a/src/Ghosts.Client/App.config
+++ b/src/Ghosts.Client/App.config
@@ -85,36 +85,8 @@
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNetCore.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral"/>
@@ -139,18 +111,6 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNetCore.Http.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.AspNetCore.Http.Features" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Embedded" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.AspNetCore.Routing" publicKeyToken="adb9793829ddae60" culture="neutral"/>
@@ -181,52 +141,12 @@
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.AspNetCore.Authorization" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Net.Http.Headers" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.8.0" newVersion="2.2.8.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.ObjectPool" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Localization.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Localization" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.AspNetCore.JsonPatch" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.WebEncoders" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
@@ -237,20 +157,8 @@
         <bindingRedirect oldVersion="0.0.0.0-3.1.3.0" newVersion="3.1.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.13.0.0" newVersion="4.13.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral"/>

--- a/src/Ghosts.Client/Ghosts.Client.csproj
+++ b/src/Ghosts.Client/Ghosts.Client.csproj
@@ -340,7 +340,7 @@
       <Version>3.5.2</Version>
     </PackageReference>
     <PackageReference Include="HtmlAgilityPack">
-      <Version>1.11.57</Version>
+      <Version>1.11.59</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Authorization">
       <Version>8.0.1</Version>

--- a/src/Ghosts.Client/Handlers/BlogHelper.cs
+++ b/src/Ghosts.Client/Handlers/BlogHelper.cs
@@ -370,6 +370,7 @@ namespace Ghosts.Client.Handlers
                             return;
                         }
                     }
+                    this.baseHandler.Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = blogAction, Trackable = timelineEvent.TrackableId });
 
                     break;
 

--- a/src/Ghosts.Client/Handlers/BlogHelper.cs
+++ b/src/Ghosts.Client/Handlers/BlogHelper.cs
@@ -370,7 +370,7 @@ namespace Ghosts.Client.Handlers
                             return;
                         }
                     }
-                    this.baseHandler.Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = blogAction, Trackable = timelineEvent.TrackableId });
+                    this.baseHandler.Report(new ReportItem { Handler = $"Blog: {handler.HandlerType.ToString()}", Command = blogAction, Arg = "", Trackable = timelineEvent.TrackableId });
 
                     break;
 

--- a/src/Ghosts.Client/Handlers/Ftp.cs
+++ b/src/Ghosts.Client/Handlers/Ftp.cs
@@ -192,7 +192,7 @@ namespace Ghosts.Client.Handlers
                     {
                         Log.Error(e); //some error occurred during this command, try the next one
                     }
-                    
+                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = hostIp, Arg = action, Trackable = timelineEvent.TrackableId });
 
                 }
                 catch (ThreadAbortException)

--- a/src/Ghosts.Client/Handlers/Notepad.cs
+++ b/src/Ghosts.Client/Handlers/Notepad.cs
@@ -147,6 +147,7 @@ namespace Ghosts.Client.Handlers
                                         break;
 
                                 }
+                                Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = action, Arg = "", Trackable = timelineEvent.TrackableId });
                             }
                             if (timelineEvent.DelayAfterActual > 0)
                                 Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayAfterActual, JitterFactor));

--- a/src/Ghosts.Client/Handlers/OutlookHelper.cs
+++ b/src/Ghosts.Client/Handlers/OutlookHelper.cs
@@ -1688,7 +1688,7 @@ namespace Ghosts.Client.Handlers
                             errorCount = errorCount + 1;
                         }
 
-                        this.baseHandler.Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = $"WebOutlook: {action}", Trackable = timelineEvent.TrackableId });
+                        this.baseHandler.Report(new ReportItem { Handler = $"WebOutlook: {handler.HandlerType.ToString()}", Command = action, Arg = "" , Trackable = timelineEvent.TrackableId });
 
                         break;
 

--- a/src/Ghosts.Client/Handlers/OutlookHelper.cs
+++ b/src/Ghosts.Client/Handlers/OutlookHelper.cs
@@ -1688,6 +1688,8 @@ namespace Ghosts.Client.Handlers
                             errorCount = errorCount + 1;
                         }
 
+                        this.baseHandler.Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = $"WebOutlook: {action}", Trackable = timelineEvent.TrackableId });
+
                         break;
 
                 }

--- a/src/Ghosts.Client/Handlers/Outlookv2.cs
+++ b/src/Ghosts.Client/Handlers/Outlookv2.cs
@@ -245,7 +245,6 @@ public class Outlookv2 : BaseHandler
                             emailConfig = new EmailConfiguration(timelineEvent.CommandArgs);
                             if (SendEmailViaOutlook(emailConfig))
                             {
-                                Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = emailConfig.ToString(), Trackable = timelineEvent.TrackableId });
                                 Log.Trace("Outlookv2:: Created email");
                                 _totalErrorCount = 0;  //zero on success
                             }
@@ -260,7 +259,7 @@ public class Outlookv2 : BaseHandler
                             emailConfig = new EmailConfiguration(timelineEvent.CommandArgs);
                             if (ReplyViaOutlook(emailConfig))
                             {
-                                Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = emailConfig.ToString(), Trackable = timelineEvent.TrackableId });
+                                
                                 Log.Trace("Outlookv2:: Replied email");
                                 _totalErrorCount = 0;  //zero on success
                             }
@@ -298,7 +297,7 @@ public class Outlookv2 : BaseHandler
                             break;
 
                     }
-
+                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = action, Arg = "", Trackable = timelineEvent.TrackableId });
                     if (timelineEvent.DelayAfterActual > 0)
                     {
                         Log.Trace($"DelayAfter sleeping for {timelineEvent.DelayAfterActual} ms");

--- a/src/Ghosts.Client/Handlers/Pidgin.cs
+++ b/src/Ghosts.Client/Handlers/Pidgin.cs
@@ -338,6 +338,7 @@ namespace Ghosts.Client.Handlers
                     {
                         sendChatMessage(imWindowTitle, thisTarget);
                         Thread.Sleep(_random.Next(TimeBetweenMessagesMin, TimeBetweenMessagesMax));
+                        Report(new ReportItem { Handler = "Pidgin", Command = thisTarget, Arg = "chat", Trackable = timelineEvent.TrackableId });
                         if (closeWindows(ErrorWindowTitles))
                         {
                             //an error window popped up. Mark this chat as bad, and close it

--- a/src/Ghosts.Client/Handlers/Rdp.cs
+++ b/src/Ghosts.Client/Handlers/Rdp.cs
@@ -316,7 +316,7 @@ namespace Ghosts.Client.Handlers
                     au.MouseMove(rc.Left, rc.Top, 30);
                     au.MouseMove(_random.Next(rc.Left, rc.Right), _random.Next(rc.Top, rc.Bottom), 30);
                     Winuser.SetForegroundWindow(winHandle);
-                    Report(new ReportItem { Handler = "WMI", Command = CurrentTarget, Arg = "mouseloop", Trackable = timelineEvent.TrackableId });
+                    Report(new ReportItem { Handler = "RDP", Command = CurrentTarget, Arg = "mouseloop", Trackable = timelineEvent.TrackableId });
                 }
                 //close the window
                 Log.Trace($"RDP:: Finished activity loop for {target}.");

--- a/src/Ghosts.Client/Handlers/Rdp.cs
+++ b/src/Ghosts.Client/Handlers/Rdp.cs
@@ -11,6 +11,7 @@ using System.IO;
 using NPOI.SS.Formula.Functions;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 using System.ComponentModel.Composition;
+using System.Runtime.InteropServices;
 
 namespace Ghosts.Client.Handlers
 {
@@ -149,6 +150,7 @@ namespace Ghosts.Client.Handlers
                                 this.RdpEx(handler, timelineEvent, choice.ToString(), au);
                             }
                             Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayAfterActual, JitterFactor));
+                            
                             break;
 
                     }
@@ -249,7 +251,7 @@ namespace Ghosts.Client.Handlers
                         //try again for another 3 minutes to find
                         if (findRdpWindow(target, 3))
                         {
-                            doMouseLoop(caption, target, au);
+                            doMouseLoop(caption, target, au, timelineEvent);
                         }
                         else
                         {
@@ -293,7 +295,7 @@ namespace Ghosts.Client.Handlers
             return winHandle != IntPtr.Zero;
         }
 
-        public void doMouseLoop(string caption, string target, AutoItX3 au)
+        public void doMouseLoop(string caption, string target, AutoItX3 au, TimelineEvent timelineEvent)
         {
             
             var winHandle = Winuser.FindWindow("TscShellContainerClass", caption);
@@ -314,6 +316,7 @@ namespace Ghosts.Client.Handlers
                     au.MouseMove(rc.Left, rc.Top, 30);
                     au.MouseMove(_random.Next(rc.Left, rc.Right), _random.Next(rc.Top, rc.Bottom), 30);
                     Winuser.SetForegroundWindow(winHandle);
+                    Report(new ReportItem { Handler = "WMI", Command = CurrentTarget, Arg = "mouseloop", Trackable = timelineEvent.TrackableId });
                 }
                 //close the window
                 Log.Trace($"RDP:: Finished activity loop for {target}.");

--- a/src/Ghosts.Client/Handlers/Sftp.cs
+++ b/src/Ghosts.Client/Handlers/Sftp.cs
@@ -199,7 +199,7 @@ namespace Ghosts.Client.Handlers
                     }
                     client.Disconnect();
                     client.Dispose();
-                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = command, Trackable = timelineEvent.TrackableId });
+                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = hostIp, Arg = cmdArgs[2], Trackable = timelineEvent.TrackableId });
                 }
             }
         }

--- a/src/Ghosts.Client/Handlers/SharepointHelper.cs
+++ b/src/Ghosts.Client/Handlers/SharepointHelper.cs
@@ -720,6 +720,8 @@ namespace Ghosts.Client.Handlers
                             return;
                         }
                     }
+
+                    this.baseHandler.Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = sharepointAction, Trackable = timelineEvent.TrackableId });
                     break;
 
 

--- a/src/Ghosts.Client/Handlers/SharepointHelper.cs
+++ b/src/Ghosts.Client/Handlers/SharepointHelper.cs
@@ -720,8 +720,8 @@ namespace Ghosts.Client.Handlers
                             return;
                         }
                     }
-
-                    this.baseHandler.Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = sharepointAction, Trackable = timelineEvent.TrackableId });
+                    
+                    this.baseHandler.Report(new ReportItem { Handler = $"Sharepoint{version}: {handler.HandlerType.ToString()}", Command = sharepointAction, Arg = "", Trackable = timelineEvent.TrackableId });
                     break;
 
 

--- a/src/Ghosts.Client/Handlers/Ssh.cs
+++ b/src/Ghosts.Client/Handlers/Ssh.cs
@@ -210,7 +210,7 @@ namespace Ghosts.Client.Handlers
                     }
                     client.Disconnect();
                     client.Dispose();
-                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = command, Trackable = timelineEvent.TrackableId });
+                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = hostIp, Arg = cmdArgs[2], Trackable = timelineEvent.TrackableId });
                 }
             }
 

--- a/src/Ghosts.Client/Handlers/Wmi.cs
+++ b/src/Ghosts.Client/Handlers/Wmi.cs
@@ -178,7 +178,7 @@ namespace Ghosts.Client.Handlers
                         }
                     }
                     client.Close();
-                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = command, Trackable = timelineEvent.TrackableId });
+                    Report(new ReportItem { Handler = handler.HandlerType.ToString(), Command = hostIp, Arg= cmdArgs[2], Trackable = timelineEvent.TrackableId });
                 }
             }
         }

--- a/src/Ghosts.Domain/ghosts.domain.csproj
+++ b/src/Ghosts.Domain/ghosts.domain.csproj
@@ -3,9 +3,9 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<RootNamespace>Ghosts.Domain</RootNamespace>
-
 		<AssemblyVersion>8.0.0.0</AssemblyVersion>
 		<FileVersion>8.0.0.0</FileVersion>
+		<Platforms>AnyCPU;x64;x86</Platforms>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/ghosts.client.linux/Comms/Updates.cs
+++ b/src/ghosts.client.linux/Comms/Updates.cs
@@ -321,7 +321,7 @@ namespace ghosts.client.linux.Comms
 
             try
             {
-                using (var s = new FileStream(tempFile, FileMode.Open, FileAccess.Read, FileShare.None))
+                using (var s = new FileStream(tempFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     using (var tr = new StreamReader(s))
                     {
@@ -349,6 +349,7 @@ namespace ghosts.client.linux.Comms
             }
             catch (Exception e)
             {
+                _log.Trace($"Client results report failed: {e}");
                 if (!string.IsNullOrEmpty(rawLogContents))
                 {
                     try

--- a/src/ghosts.client.linux/Handlers/BaseHandler.cs
+++ b/src/ghosts.client.linux/Handlers/BaseHandler.cs
@@ -19,7 +19,7 @@ namespace ghosts.client.linux.handlers
             WorkingHours.Is(handler);
         }
 
-        protected static void Report(ReportItem reportItem)
+        public void Report(ReportItem reportItem)
         {
             var result = new TimeLineRecord
             {

--- a/src/ghosts.client.linux/Handlers/BlogHelper.cs
+++ b/src/ghosts.client.linux/Handlers/BlogHelper.cs
@@ -370,6 +370,8 @@ namespace ghosts.client.linux.handlers
                             return;
                         }
                     }
+                    this.baseHandler.Report(new ReportItem {Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = blogAction, Trackable = timelineEvent.TrackableId});
+
 
                     break;
 

--- a/src/ghosts.client.linux/Handlers/BlogHelper.cs
+++ b/src/ghosts.client.linux/Handlers/BlogHelper.cs
@@ -370,7 +370,7 @@ namespace ghosts.client.linux.handlers
                             return;
                         }
                     }
-                    this.baseHandler.Report(new ReportItem {Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = blogAction, Trackable = timelineEvent.TrackableId});
+                    this.baseHandler.Report(new ReportItem {Handler = $"Blog: {handler.HandlerType.ToString()}", Command = blogAction, Arg = "", Trackable = timelineEvent.TrackableId});
 
 
                     break;

--- a/src/ghosts.client.linux/Handlers/BrowserChrome.cs
+++ b/src/ghosts.client.linux/Handlers/BrowserChrome.cs
@@ -109,13 +109,18 @@ namespace ghosts.client.linux.handlers
                         options.AddArgument(option.Value<string>());
                     }
                 }
-                //used to kill process
+                //used to kill process as Selenium driver sometimes fails
+                string browserId;
                 if (handler.HandlerArgs.ContainsKey("browser-id") &&
                     !string.IsNullOrEmpty(handler.HandlerArgs["browser-id"].ToString()))
                 {
-                    var s = handler.HandlerArgs["browser-id"].ToString();
-                    options.AddArgument($"--{s}");
+                    browserId = handler.HandlerArgs["browser-id"].ToString();
+                } else {
+                    // always generate this, and save
+                    browserId = Guid.NewGuid().ToString();
+                    handler.HandlerArgs["browser-id"] = browserId;
                 }
+                options.AddArgument($"--{browserId}");
 
 
                 if (handler.HandlerArgs.ContainsKey("executable-location") &&

--- a/src/ghosts.client.linux/Handlers/BrowserFirefox.cs
+++ b/src/ghosts.client.linux/Handlers/BrowserFirefox.cs
@@ -209,13 +209,19 @@ namespace ghosts.client.linux.handlers
                         options.AddArgument(option.Value<string>());
                     }
                 }
-                //used to kill process
+                //used to kill process as Selenium driver sometimes fails
+                string browserId;
                 if (handler.HandlerArgs.ContainsKey("browser-id") &&
                     !string.IsNullOrEmpty(handler.HandlerArgs["browser-id"].ToString()))
                 {
-                    var s = handler.HandlerArgs["browser-id"].ToString();
-                    options.AddArgument($"--{s}");
+                    browserId = handler.HandlerArgs["browser-id"].ToString();
+                } else {
+                    // always generate this, and save
+                    browserId = Guid.NewGuid().ToString();
+                    handler.HandlerArgs["browser-id"] = browserId;
                 }
+                options.AddArgument($"--{browserId}");
+                
 
                 if (handler.HandlerArgs.ContainsKeyWithOption("isheadless", "true"))
                 {

--- a/src/ghosts.client.linux/Handlers/OutlookHelper.cs
+++ b/src/ghosts.client.linux/Handlers/OutlookHelper.cs
@@ -1678,6 +1678,8 @@ namespace ghosts.client.linux.handlers
                             Log.Trace($"WebOutlook:: Failed action: {action}.");
                             errorCount = errorCount + 1;
                         }
+                        this.baseHandler.Report(new ReportItem {Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = $"WebOutlook: {action}", Trackable = timelineEvent.TrackableId});
+
                         
                         break;
 

--- a/src/ghosts.client.linux/Handlers/OutlookHelper.cs
+++ b/src/ghosts.client.linux/Handlers/OutlookHelper.cs
@@ -1678,7 +1678,8 @@ namespace ghosts.client.linux.handlers
                             Log.Trace($"WebOutlook:: Failed action: {action}.");
                             errorCount = errorCount + 1;
                         }
-                        this.baseHandler.Report(new ReportItem {Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = $"WebOutlook: {action}", Trackable = timelineEvent.TrackableId});
+                        var handlerName = handler.HandlerType.ToString();
+                        this.baseHandler.Report(new ReportItem {Handler = $"WebOutlook: {handler.HandlerType.ToString()}", Command = action, Arg = "", Trackable = timelineEvent.TrackableId});
 
                         
                         break;

--- a/src/ghosts.client.linux/Handlers/Sftp.cs
+++ b/src/ghosts.client.linux/Handlers/Sftp.cs
@@ -199,7 +199,7 @@ namespace ghosts.client.linux.handlers
                     }
                     client.Disconnect();
                     client.Dispose();
-                    //this.Report(handler.HandlerType.ToString(), command, "", timelineEvent.TrackableId);
+                    Report(new ReportItem {Handler=handler.HandlerType.ToString(), Command= hostIp, Arg = cmdArgs[2], Trackable =  timelineEvent.TrackableId });
                 }
             }
         }

--- a/src/ghosts.client.linux/Handlers/SharepointHelper.cs
+++ b/src/ghosts.client.linux/Handlers/SharepointHelper.cs
@@ -714,6 +714,7 @@ namespace ghosts.client.linux.handlers
                             return;
                         }
                     }
+                    this.baseHandler.Report(new ReportItem {Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = sharepointAction, Trackable = timelineEvent.TrackableId});
                     break;
 
 

--- a/src/ghosts.client.linux/Handlers/SharepointHelper.cs
+++ b/src/ghosts.client.linux/Handlers/SharepointHelper.cs
@@ -714,7 +714,7 @@ namespace ghosts.client.linux.handlers
                             return;
                         }
                     }
-                    this.baseHandler.Report(new ReportItem {Handler = handler.HandlerType.ToString(), Command = timelineEvent.Command, Arg = sharepointAction, Trackable = timelineEvent.TrackableId});
+                    this.baseHandler.Report(new ReportItem {Handler = $"Sharepoint{version}: {handler.HandlerType.ToString()}", Command = sharepointAction, Arg = "", Trackable = timelineEvent.TrackableId});
                     break;
 
 

--- a/src/ghosts.client.linux/Handlers/Ssh.cs
+++ b/src/ghosts.client.linux/Handlers/Ssh.cs
@@ -209,7 +209,7 @@ namespace ghosts.client.linux.handlers
                     }
                     client.Disconnect();
                     client.Dispose();
-                    //this.Report(handler.HandlerType.ToString(), command, "", timelineEvent.TrackableId);
+                    Report(new ReportItem {Handler = handler.HandlerType.ToString(), Command= hostIp, Arg = cmdArgs[2], Trackable = timelineEvent.TrackableId });
                 }
             }
 


### PR DESCRIPTION
These changes add API reporting to the newer handlers that did not have reporting. Some reporting messages were changed to make it clearer what was being done by clients. There is also a problem in Comms/Updates.cs on the linux side that prevented any linux updates from being sent, for some reason the working code on the Windows client did not function the same way on the linux side - a small change fixed the problem.

This is a snapshot of API reporting in our GHOSTS regression test.

![dashboard_snap](https://github.com/cmu-sei/GHOSTS/assets/4985789/97aef1ab-9585-4ff6-94cc-8f5bb6686815)
