### PR TITLE
Made Linux WebEmail attachments more robust

### DIFF
--- a/src/ghosts.client.linux/Handlers/OutlookHelper.cs
+++ b/src/ghosts.client.linux/Handlers/OutlookHelper.cs
@@ -150,6 +150,7 @@ namespace ghosts.client.linux.handlers
 
 
         public string FileDownloadAllXpath { get; set; } = "//span[text()='Download all']/parent::button";
+        public string FileDownloadXpath { get; set; } = "//span[text()='Download']/parent::button";
 
         private LinuxSupport linuxHelper = null;
 
@@ -1275,6 +1276,7 @@ namespace ghosts.client.linux.handlers
                 IWebElement targetElement = null;
                 if (saveAttachmentProbability > _random.Next(0, 100))
                 {
+                    bool didDownload = false;
                     try
                     {
                         targetElement = Driver.FindElement(By.XPath(FileDownloadAllXpath));
@@ -1290,9 +1292,34 @@ namespace ghosts.client.linux.handlers
 
                     if (targetElement != null)
                     {
+                        didDownload = true;
                         BrowserHelperSupport.ElementClick(Driver, targetElement);
                         Thread.Sleep(300);
                         Log.Trace($"WebOutlook:: Attachments downloads successfull.");
+                    }
+                    if (!didDownload)
+                    {
+                        try
+                        {
+                            targetElement = Driver.FindElement(By.XPath(FileDownloadXpath));
+                        }
+                        catch (Exception e)
+                        {
+                            if (e is ThreadAbortException || e is ThreadInterruptedException)
+                            {
+                                throw;
+                            }
+                            //ignore may not be present
+                        }
+
+                        if (targetElement != null)
+                        {
+                            didDownload = true;
+                            BrowserHelperSupport.ElementClick(Driver, targetElement);
+                            Thread.Sleep(300);
+                            Log.Trace($"WebOutlook:: Single Attachment download successfull.");
+                        }
+
                     }
                 }
             }

--- a/src/ghosts.client.linux/Infrastructure/LinuxSupport.cs
+++ b/src/ghosts.client.linux/Infrastructure/LinuxSupport.cs
@@ -75,19 +75,29 @@ namespace ghosts.client.linux.Infrastructure
             {
                 var cmd = $"xdotool search -name '{windowTitle}' windowfocus type '{filename}' ";
                 ExecuteBashCommand(id, cmd);
-                Thread.Sleep(2000);
+                Thread.Sleep(3000);
                 cmd = $"xdotool search -name '{windowTitle}' windowfocus key KP_Enter";
                 ExecuteBashCommand(id, cmd);
-                Thread.Sleep(2000);
-                // Check if the window has closed
-                cmd = $"xdotool search -name '{windowTitle}'";
-                var result = ExecuteBashCommand(id, cmd);
-                if (result != "")
+                Thread.Sleep(3000);  // this is the actual upload
+                // Check if the window has closed, do multiple close attempts
+                int i = 0;
+                while (i < 10)
                 {
-                    // close the window
-                    cmd = $"xdotool search -name '{windowTitle}' windowfocus key alt+c";
-                    ExecuteBashCommand(id, cmd);
-                    Thread.Sleep(500);
+                    cmd = $"xdotool search -name '{windowTitle}'";
+                    string result = ExecuteBashCommand(id, cmd);
+                    Thread.Sleep(1000);
+                    if (result != "")
+                    {
+                        // close the window
+                        cmd = $"xdotool search -name '{windowTitle}' windowfocus key alt+c";
+                        ExecuteBashCommand(id, cmd);
+                        Thread.Sleep(1000);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    i += 1;
                 }
                 return;
             }


### PR DESCRIPTION
Here are some minor changes from the latest release of GHOSTS in our events.  This makes the Outlook WebEmail attachment process for Linux clients more robust. We were having problems with occasional attachment fails or orphaned windows. We have found Chrome to be a better choice than Firefox on later versions of Ubuntu, Kali, Rocky8/9 for Outlook WebEmail.  This also affects attachments in the Linux Social Web handler as it uses the same code.
