### PR TITLE
Timelinefix mar2025

### DIFF
--- a/src/Ghosts.Client/Handlers/BlogHelper.cs
+++ b/src/Ghosts.Client/Handlers/BlogHelper.cs
@@ -150,7 +150,7 @@ namespace Ghosts.Client.Handlers
         /// <param name="timelineEvent"></param>
         public void Execute(TimelineHandler handler, TimelineEvent timelineEvent)
         {
-            string credFname;
+            string credFname = null;
             string credentialKey = null;
             
 
@@ -215,12 +215,9 @@ namespace Ghosts.Client.Handlers
                         baseHandler.JitterFactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
                     }
 
-
-                    credFname = handler.HandlerArgs["blog-credentials-file"].ToString();
-
                     if (handler.HandlerArgs.ContainsKey("blog-credentials-file"))
                     {
-
+                        credFname = handler.HandlerArgs["blog-credentials-file"].ToString();
                         try
                         {
                             _credentials = JsonConvert.DeserializeObject<Credentials>(System.IO.File.ReadAllText(credFname));
@@ -232,6 +229,29 @@ namespace Ghosts.Client.Handlers
                             Log.Error(e);
                             return;
                         }
+                    }
+
+                    if (handler.HandlerArgs.ContainsKey("blog-credentials"))
+                    {
+
+                        try
+                        {
+                            _credentials = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["blog-credentials"].ToString());
+                        }
+                        catch (System.Exception e)
+                        {
+                            Log.Trace($"Blog:: Error parsing blog credentials , blog browser action will not be executed.");
+                            baseHandler.BlogAbort = true;
+                            Log.Error(e);
+                            return;
+                        }
+                    }
+
+                    if (_credentials == null)
+                    {
+                        Log.Trace($"Blog:: No credentials specified in handler-args, blog browser action will not be executed.");
+                        baseHandler.BlogAbort = true;
+                        return;
                     }
 
                     //now parse the command args
@@ -297,7 +317,7 @@ namespace Ghosts.Client.Handlers
 
                     if (username == null || password == null)
                     {
-                        Log.Trace($"Blog:: The credential key {credentialKey} does not return a valid credential from file {credFname}, blog browser action will not be executed");
+                        Log.Trace($"Blog:: The credential key {credentialKey} does not return a valid credential, blog browser action will not be executed");
                         baseHandler.BlogAbort = true;
                         return;
                     }

--- a/src/Ghosts.Client/Handlers/Ftp.cs
+++ b/src/Ghosts.Client/Handlers/Ftp.cs
@@ -41,6 +41,21 @@ namespace Ghosts.Client.Handlers
                             Log.Error(e);
                         }
                     }
+                    if (handler.HandlerArgs.ContainsKey("Credentials"))
+                    {
+                        try
+                        {
+                            this.CurrentCreds = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["Credentials"].ToString());
+                        }
+                        catch (ThreadAbortException)
+                        {
+                            throw;  //pass up
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(e);
+                        }
+                    }
                     if (handler.HandlerArgs.ContainsKey("UploadDirectory"))
                     {
                         string targetDir = handler.HandlerArgs["UploadDirectory"].ToString();
@@ -103,6 +118,11 @@ namespace Ghosts.Client.Handlers
                     this.CurrentFtpSupport.deletionProbability = 20;
                 }
 
+                if (this.CurrentCreds == null)
+                {
+                    Log.Error($"Ftp:: No credentials supplied, either CredentialsFile or Credentials must be supplied in handler args, exiting.");
+                    return;
+                }
 
 
                 if (handler.Loop)

--- a/src/Ghosts.Client/Handlers/Rdp.cs
+++ b/src/Ghosts.Client/Handlers/Rdp.cs
@@ -96,6 +96,17 @@ namespace Ghosts.Client.Handlers
                         Log.Error(e);
                     }
                 }
+                if (handler.HandlerArgs.ContainsKey("Credentials"))
+                {
+                    try
+                    {
+                        this.CurrentCreds = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["Credentials"].ToString());
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e);
+                    }
+                }
                 if (handler.HandlerArgs.ContainsKey("mouse-sleep-time"))
                 {
                     int.TryParse(handler.HandlerArgs["mouse-sleep-time"].ToString(), out MouseSleep);
@@ -121,6 +132,11 @@ namespace Ghosts.Client.Handlers
                 {
                     JitterFactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
                 }
+            }
+            if (this.CurrentCreds == null)
+            {
+                Log.Error($"RDP:: No credentials supplied, either CredentialsFile or Credentials must be supplied in handler args, exiting.");
+                return;
             }
             AutoItX3 au = new AutoItX3();
 

--- a/src/Ghosts.Client/Handlers/Sftp.cs
+++ b/src/Ghosts.Client/Handlers/Sftp.cs
@@ -40,6 +40,21 @@ namespace Ghosts.Client.Handlers
                             Log.Error(e);
                         }
                     }
+                    if (handler.HandlerArgs.ContainsKey("Credentials"))
+                    {
+                        try
+                        {
+                            this.CurrentCreds = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["Credentials"].ToString());
+                        }
+                        catch (ThreadAbortException)
+                        {
+                            throw;  //pass up
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(e);
+                        }
+                    }
 
                     if (handler.HandlerArgs.ContainsKey("TimeBetweenCommandsMax"))
                     {
@@ -95,9 +110,11 @@ namespace Ghosts.Client.Handlers
                         jitterfactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
                     }
                 }
-
-
-
+                if (this.CurrentCreds == null)
+                {
+                    Log.Error($"Sftp:: No credentials supplied, either CredentialsFile or Credentials must be supplied in handler args, exiting.");
+                    return;
+                }
                 if (handler.Loop)
                 {
                     while (true)

--- a/src/Ghosts.Client/Handlers/SharepointHelper.cs
+++ b/src/Ghosts.Client/Handlers/SharepointHelper.cs
@@ -500,7 +500,7 @@ namespace Ghosts.Client.Handlers
         /// <param name="timelineEvent"></param>
         public void Execute(TimelineHandler handler, TimelineEvent timelineEvent)
         {
-            string credFname;
+            string credFname = null;
             string credentialKey = null;
 
 
@@ -576,11 +576,9 @@ namespace Ghosts.Client.Handlers
                         baseHandler.JitterFactor = Jitter.JitterFactorParse(handler.HandlerArgs["delay-jitter"].ToString());
                     }
 
-                    credFname = handler.HandlerArgs["sharepoint-credentials-file"].ToString();
-
                     if (handler.HandlerArgs.ContainsKey("sharepoint-credentials-file"))
                     {
-
+                        credFname = handler.HandlerArgs["sharepoint-credentials-file"].ToString();
                         try
                         {
                             _credentials = JsonConvert.DeserializeObject<Credentials>(System.IO.File.ReadAllText(credFname));
@@ -592,6 +590,29 @@ namespace Ghosts.Client.Handlers
                             Log.Error(e);
                             return;
                         }
+                    }
+
+                    if (handler.HandlerArgs.ContainsKey("sharepoint-credentials"))
+                    {
+
+                        try
+                        {
+                            _credentials = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["sharepoint-credentials"].ToString());
+                        }
+                        catch (System.Exception e)
+                        {
+                            Log.Trace($"Sharepoint:: Error parsing sharepoint credentials , sharepoint browser action will not be executed.");
+                            baseHandler.SharePointAbort = true;
+                            Log.Error(e);
+                            return;
+                        }
+                    }
+
+                    if (_credentials == null)
+                    {
+                        Log.Trace($"Sharepoint:: No credentials specified in handler-args, sharepoint browser action will not be executed.");
+                        baseHandler.SharePointAbort = true;
+                        return;
                     }
 
                     //now parse the command args
@@ -657,7 +678,7 @@ namespace Ghosts.Client.Handlers
 
                     if (username == null || password == null)
                     {
-                        Log.Trace($"Sharepoint:: The credential key {credentialKey} does not return a valid credential from file {credFname},   sharepoint browser action will not be executed");
+                        Log.Trace($"Sharepoint:: The credential key {credentialKey} does not return a valid credential, sharepoint browser action will not be executed");
                         baseHandler.SharePointAbort = true;
                         return;
                     }

--- a/src/Ghosts.Client/Handlers/Ssh.cs
+++ b/src/Ghosts.Client/Handlers/Ssh.cs
@@ -46,6 +46,25 @@ namespace Ghosts.Client.Handlers
                         {
                             this.CurrentCreds = JsonConvert.DeserializeObject<Credentials>(File.ReadAllText(handler.HandlerArgs["CredentialsFile"].ToString()));
                         }
+                        catch (ThreadAbortException)
+                        {
+                            throw;  //pass up
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(e);
+                        }
+                    }
+                    if (handler.HandlerArgs.ContainsKey("Credentials"))
+                    {
+                        try
+                        {
+                            this.CurrentCreds = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["Credentials"].ToString());
+                        }
+                        catch (ThreadAbortException)
+                        {
+                            throw;  //pass up
+                        }
                         catch (Exception e)
                         {
                             Log.Error(e);
@@ -103,7 +122,11 @@ namespace Ghosts.Client.Handlers
                     }
                 }
 
-
+                if (this.CurrentCreds == null)
+                {
+                    Log.Error($"SSH:: No credentials supplied, either CredentialsFile or Credentials must be supplied in handler args, exiting.");
+                    return;
+                }
 
                 if (handler.Loop)
                 {
@@ -119,7 +142,7 @@ namespace Ghosts.Client.Handlers
             }
             catch (ThreadAbortException)
             {
-                Log.Trace("Ssh closing...");
+                Log.Trace("SSH closing...");
             }
             catch (Exception e)
             {

--- a/src/Ghosts.Client/Handlers/Wmi.cs
+++ b/src/Ghosts.Client/Handlers/Wmi.cs
@@ -35,7 +35,21 @@ namespace Ghosts.Client.Handlers
                             Log.Error(e);
                         }
                     }
-
+                    if (handler.HandlerArgs.ContainsKey("Credentials"))
+                    {
+                        try
+                        {
+                            this.CurrentCreds = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["Credentials"].ToString());
+                        }
+                        catch (ThreadAbortException)
+                        {
+                            throw;  //pass up
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(e);
+                        }
+                    }
                     if (handler.HandlerArgs.ContainsKey("TimeBetweenCommandsMax"))
                     {
                         try
@@ -61,9 +75,11 @@ namespace Ghosts.Client.Handlers
                         }
                     }
                 }
-
-
-
+                if (this.CurrentCreds == null)
+                {
+                    Log.Error($"WMI:: No credentials supplied, either CredentialsFile or Credentials must be supplied in handler args, exiting.");
+                    return;
+                }
                 if (handler.Loop)
                 {
                     while (true)

--- a/src/Ghosts.Client/Infrastructure/Email/EmailConfiguration.cs
+++ b/src/Ghosts.Client/Infrastructure/Email/EmailConfiguration.cs
@@ -52,7 +52,7 @@ public class EmailConfiguration
     public List<string> Attachments { get; }
     public EmailBodyType BodyType { get; }
 
-    public EmailConfiguration(IList<object> args)
+    public EmailConfiguration(IList<object> args, List<string> domainEmailList = null)
     {
         _log.Trace($"Building email configuration from timeline {JsonConvert.SerializeObject(args)}...");
 
@@ -78,9 +78,9 @@ public class EmailConfiguration
         //    this.From = $"{Environment.UserName}@{System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName}";
         //}
 
-        this.To = ParseEmail(emailConfigArray[1].ToString(), settings.RecipientsToMin, settings.RecipientsToMax);
-        this.Cc = ParseEmail(emailConfigArray[2].ToString(), settings.RecipientsCcMin, settings.RecipientsCcMax);
-        this.Bcc = ParseEmail(emailConfigArray[3].ToString(), settings.RecipientsBccMin, settings.RecipientsBccMax);
+        this.To = ParseEmail(emailConfigArray[1].ToString(), settings.RecipientsToMin, settings.RecipientsToMax, domainEmailList);
+        this.Cc = ParseEmail(emailConfigArray[2].ToString(), settings.RecipientsCcMin, settings.RecipientsCcMax, domainEmailList);
+        this.Bcc = ParseEmail(emailConfigArray[3].ToString(), settings.RecipientsBccMin, settings.RecipientsBccMax, domainEmailList);
 
         var emailContent = new EmailContentManager();
 
@@ -169,7 +169,7 @@ public class EmailConfiguration
         return $"Sending email from: {this.From} to: {string.Join(",", this.To)} cc: {string.Join(",", this.Cc)} bcc: {string.Join(",", this.Bcc)}";
     }
 
-    private static List<string> ParseEmail(string raw, int min, int max)
+    private static List<string> ParseEmail(string raw, int min, int max, List<string> domainEmailList = null)
     {
         _log.Trace($"Parsing email - raw {raw} min {min} max {max}");
         var list = new List<string>();
@@ -187,7 +187,12 @@ public class EmailConfiguration
         if (raw.StartsWith("random", StringComparison.InvariantCultureIgnoreCase))
         {
             //add domain
-            var emails = EmailListManager.GetDomainList();
+            var emails = domainEmailList;
+            if (emails == null)
+            {
+                emails = EmailListManager.GetDomainList();
+            }
+            
             _log.Trace($"Building domain email list: {emails.Count}...");
 
             for (var i = 0; i < numberOfRecipients; i++)

--- a/src/Ghosts.Client/Sample Timelines/BrowserChromeBlogDrupal.json
+++ b/src/Ghosts.Client/Sample Timelines/BrowserChromeBlogDrupal.json
@@ -39,24 +39,36 @@
   "TimeLineHandlers": [
     {
       "HandlerType": "BrowserChrome",
-      "HandlerArgs": {
-        "isheadless": "false",
-        "blockimages": "true",
-        "blockstyles": "true",
-        "blockflash": "true",
-        "blockscripts": "true",
-        "stickiness": 75,
-        "stickiness-depth-min": 5,
-        "stickiness-depth-max": 10000,
-        "incognito": "true",
-        "blog-credentials-file": "c:\\ghosts_data\\blog_creds.json",
-        "blog-deletion-probability": 0,
-        "blog-upload-probability": 0,
-        "blog-browse-probability": 0,
-        "blog-reply-probability": 100,
-        "blog-version": "drupal"
+        "HandlerArgs": {
+            "isheadless": "false",
+            "blockimages": "true",
+            "blockstyles": "true",
+            "blockflash": "true",
+            "blockscripts": "true",
+            "stickiness": 75,
+            "stickiness-depth-min": 5,
+            "stickiness-depth-max": 10000,
+            "incognito": "true",
+            // either blog-credentials-file or blog-credentials must be defined
+            // if both  blog-credentials-file and blog-credentials present, then blog-credentials takes precedence.
+            // Use blog-credentials arg to store credentials directly in the timeline 
+            "blog-credentials-file": "<path to credentials>", // file path to a JSON file containing the blog credentials
+            "blog-credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "bloguser": {
+                        "username": "bloguser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
+            "blog-deletion-probability": 0,
+            "blog-upload-probability": 0,
+            "blog-browse-probability": 0,
+            "blog-reply-probability": 100,
+            "blog-version": "drupal"
 
-      },
+        },
       "Initial": "about:blank",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",

--- a/src/Ghosts.Client/Sample Timelines/BrowserChromeSharepoint.json
+++ b/src/Ghosts.Client/Sample Timelines/BrowserChromeSharepoint.json
@@ -6,7 +6,7 @@
     "sharepoint-deletion-probability": <0-100 integer>, default  0
     "sharepoint-upload-probability": <0-100 integer>, default 0
     "sharepoint-download-probability": <0-100 integer>, default 0, sum of download+deletion+upload <= 100, download directory is browser download directory
-    "sharepoint-version": "2013",  -- version, required, only 2013 is currrently supported
+    "sharepoint-version": "2013",  -- version, required, 2013 and 2019 are currently supported
     "sharepoint-upload-directory": <upload directory path>" -- files to be uploaded are read from this directory, default is browser download directory
 
   The CommandArgs are strings of the form "key:value", supported args are:
@@ -29,24 +29,36 @@
   "TimeLineHandlers": [
     {
       "HandlerType": "BrowserChrome",
-      "HandlerArgs": {
-        "isheadless": "false",
-        "blockimages": "true",
-        "blockstyles": "true",
-        "blockflash": "true",
-        "blockscripts": "true",
-        "stickiness": 75,
-        "stickiness-depth-min": 5,
-        "stickiness-depth-max": 10000,
-        "incognito": "true",
-        "sharepoint-credentials-file": "c:\\ghosts_data\\sharepoint_creds.json",
-        "sharepoint-deletion-probability": 15,
-        "sharepoint-upload-probability": 35,
-        "sharepoint-download-probability": 35,
-        "sharepoint-version": "2013",
-        "sharepoint-upload-directory": "C:\\ghosts_data\\uploads"
+        "HandlerArgs": {
+            "isheadless": "false",
+            "blockimages": "true",
+            "blockstyles": "true",
+            "blockflash": "true",
+            "blockscripts": "true",
+            "stickiness": 75,
+            "stickiness-depth-min": 5,
+            "stickiness-depth-max": 10000,
+            "incognito": "true",
+            // either sharepoint-credentials-file or sharepoint-credentials must be defined
+            // if both  sharepoint-credentials-file and sharepoint-credentials present, then sharepoint-credentials takes precedence.
+            // Use sharepoint-credentials arg to store credentials directly in the timeline 
+            "sharepoint-credentials-file": "<path to credentials>", // file path to a JSON file containing the sharepoint credentials
+            "sharepoint-credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "sharepointuser": {
+                        "username": "sharepointuser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
+            "sharepoint-deletion-probability": 15,
+            "sharepoint-upload-probability": 35,
+            "sharepoint-download-probability": 35,
+            "sharepoint-version": "2013",
+            "sharepoint-upload-directory": "C:\\ghosts_data\\uploads"
 
-      },
+        },
       "Initial": "about:blank",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",

--- a/src/Ghosts.Client/Sample Timelines/BrowserOutlook.json
+++ b/src/Ghosts.Client/Sample Timelines/BrowserOutlook.json
@@ -42,25 +42,38 @@
       "Initial": "about:blank",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24.00:00:00",
-      "HandlerArgs": {
-        "isheadless": "false",
-        "delay-jitter": 50, //%jitter to add to delayAfter, delayBefore
-        "browser-id": "ghosts-client-outlook", //This is only used in the Linux client to delete the Outlook browser process on restart as sometimes the normal Selenium shutdown fails to close the browser
-        "outlook-credentials-file": "<path to credentials file>", //path to credentials files
-        "outlook-delete-probability": 20, //probability that a delete operation will be done
-        "outlook-read-probability": 30, //probability that an existing email will be read, unread is given preference
-        "outlook-reply-probability": 20, //probability that a reply to an existing email is created
-        "outlook-create-probability": 30, //probability that a new email will be created
-        "outlook-attachment-probability": 100, //when creating a new email, probability that attachments are added
-        "outlook-save-attachment-probability": 100, //when reading a email, probability that emails are saved to disk
-        "outlook-min-attachments": 0, //when adding an attachment, min number of attachments
-        "outlook-max-attachments": 3, //when adding an attachment, max number of attachments
-        "outlook-max-attachments-size": 10, //in MB, total size of all attachments will not exceed this
-        "outlook-url": "https://enc01-exchg2013.sitea.com/owa", // URL to Exchange Outlook server
-        "outlook-credential-key": "<aCredentialKey>", //this key used to look up a username/password credential
-        "exchange-version": "2013", //Exchange Web server version, only 2013 is supported at this time
-        "outlook-uploads-directory": "<path to uploads file>" //path to directory contains files to be used for attachments
-      },
+        "HandlerArgs": {
+            "isheadless": "false",
+            "delay-jitter": 50, //%jitter to add to delayAfter, delayBefore
+            "browser-id": "ghosts-client-outlook", //This is only used in the Linux client to delete the Outlook browser process on restart as sometimes the normal Selenium shutdown fails to close the browser
+            // either outlook-credentials-file or outlook-credentials must be defined
+            // if both  outlook-credentials-file and outlook-credentials present, then outlook-credentials takes precedence.
+            // Use outlook-credentials arg to store credentials directly in the timeline 
+            "outlook-credentials-file": "<path to credentials>", // file path to a JSON file containing the outlook credentials
+            "outlook-credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "outlookuser": {
+                        "username": "outlookuser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
+            "outlook-email-domain-addresses":  [ "johndoe@somedomain", "mary@somedomain"], //optional, replaces EmailDomain in application config
+            "outlook-delete-probability": 20, //probability that a delete operation will be done
+            "outlook-read-probability": 30, //probability that an existing email will be read, unread is given preference
+            "outlook-reply-probability": 20, //probability that a reply to an existing email is created
+            "outlook-create-probability": 30, //probability that a new email will be created
+            "outlook-attachment-probability": 100, //when creating a new email, probability that attachments are added
+            "outlook-save-attachment-probability": 100, //when reading a email, probability that emails are saved to disk
+            "outlook-min-attachments": 0, //when adding an attachment, min number of attachments
+            "outlook-max-attachments": 3, //when adding an attachment, max number of attachments
+            "outlook-max-attachments-size": 10, //in MB, total size of all attachments will not exceed this
+            "outlook-url": "https://enc01-exchg2013.sitea.com/owa", // URL to Exchange Outlook server
+            "outlook-credential-key": "<aCredentialKey>", //this key used to look up a username/password credential
+            "exchange-version": "2013", //Exchange Web server version, only 2013 is supported at this time
+            "outlook-uploads-directory": "<path to uploads file>" //path to directory contains files to be used for attachments
+        },
       "Loop": true,
       "TimeLineEvents": [
         {

--- a/src/Ghosts.Client/Sample Timelines/Ftp.json
+++ b/src/Ghosts.Client/Sample Timelines/Ftp.json
@@ -10,10 +10,26 @@
     {
       "HandlerType": "Ftp",
         "HandlerArgs": {
-            "deletion-probability": 20,  //deletion of random file from FTP server
-            "upload-probability": 40,    //upload of random file to FTP server
+            "deletion-probability": 20, //deletion of random file from FTP server
+            "upload-probability": 40, //upload of random file to FTP server
             "download-probability": 40, //download of random file from FTP
-            "CredentialsFile": "C:\\ghosts_data\\ftp_creds.json", //required, file path to a JSON file containing the FTP credentials
+            // either Credentials File or Credentials must be defined
+            // if both Credentials and CredentialFile present, then Credentials takes precedence.
+            // Use Credentials arg to store Credentials directly in the timeline 
+            "CredentialsFile": "<path to credentials>", // file path to a JSON file containing the SSH credentials
+            "Credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "xx.xx.xx.xx_ahostname": {
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    },
+                    "yy.xx.xx.xx_ahostname": {
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
             "UploadDirectory": "C:\\ghosts_data\\uploads", //optional, directory that contains files for upload, it not specified user Downloads directory is used
             "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
         },

--- a/src/Ghosts.Client/Sample Timelines/Outlookv2.json
+++ b/src/Ghosts.Client/Sample Timelines/Outlookv2.json
@@ -22,21 +22,22 @@
       "Initial": "",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24.00:00:00",
-      "HandlerArgs": {
-        "delay-jitter": 50, //%jitter to add to delayAfter, delayBefore
-        "delete-probability": 0, //probability that a delete operation will be done
-        "create-probability": 0, //probability that a new email will be created
-        "read-probability": 100, //probability that an existing email will be read, unread is given preference
-        "reply-probability": 0, //probability that a reply to an existing email is created
-        "click-probability": 35, //TODO, not implemented yet
-        "attachment-probability": 100, //when creating a new email, probability that attachments are added
-        "save-attachment-probability": 100, //when reading a email, probability that emails are saved to disk
-        "min-attachments": 5, //when adding an attachment, min number of attachments
-        "max-attachments": 5, //when adding an attachment, max number of attachments
-        "max-attachments-size": 10, //in MB, total size of all attachments will not exceed this
-        "input-directory": "C:\\ghosts_data\\uploads", // source directory for attachments
-        "output-directory": "C:\\ghosts_data\\downloads" // target directory for saved attachments, created if does not exist
-      },
+        "HandlerArgs": {
+            "domain-addresses": [ "johndoe@somedomain", "mary@somedomain" ], //optional, replaces EmailDomain in application config
+            "delay-jitter": 50, //%jitter to add to delayAfter, delayBefore
+            "delete-probability": 0, //probability that a delete operation will be done
+            "create-probability": 0, //probability that a new email will be created
+            "read-probability": 100, //probability that an existing email will be read, unread is given preference
+            "reply-probability": 0, //probability that a reply to an existing email is created
+            "click-probability": 35, //TODO, not implemented yet
+            "attachment-probability": 100, //when creating a new email, probability that attachments are added
+            "save-attachment-probability": 100, //when reading a email, probability that emails are saved to disk
+            "min-attachments": 5, //when adding an attachment, min number of attachments
+            "max-attachments": 5, //when adding an attachment, max number of attachments
+            "max-attachments-size": 10, //in MB, total size of all attachments will not exceed this
+            "input-directory": "C:\\ghosts_data\\uploads", // source directory for attachments
+            "output-directory": "C:\\ghosts_data\\downloads" // target directory for saved attachments, created if does not exist
+        },
       "Loop": true,
       "TimeLineEvents": [
         {

--- a/src/Ghosts.Client/Sample Timelines/Rdp.json
+++ b/src/Ghosts.Client/Sample Timelines/Rdp.json
@@ -57,15 +57,28 @@
   "TimeLineHandlers": [
     {
       "HandlerType": "Rdp",
-      "HandlerArgs": {
-        "CredentialsFile": "<path to credentials>", //required, file path to a JSON file containing the RDP credentials
-        "mouse-sleep-time": 10000, //time to sleep between random mouse movements
-        "execution-time": 60000, //after this total connection time has elapsed, the RDP is closed and a new connection opened
-        "custom-login": "#PASSWORD\n#DELAY1000\n{TAB}\n{TAB}\n{TAB}\n{ENTER}", //see explanation above
-        "execution-probability": 100, //after choosing a random target, the probability that a RDP to the target is opened
-        "delay-jitter": 50
+        "HandlerArgs": {
+            // either Credentials File or Credentials must be defined
+            // if both Credentials and CredentialFile present, then Credentials takes precedence.
+            // Use Credentials arg to store Credentials directly in the timeline 
+            "CredentialsFile": "<path to credentials>", // file path to a JSON file containing the RDP credentials
+            "Credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "xx.xx.xx.xx": {
+                        "domain": "domainname",  //optional
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
+            "mouse-sleep-time": 10000, //time to sleep between random mouse movements
+            "execution-time": 60000, //after this total connection time has elapsed, the RDP is closed and a new connection opened
+            "custom-login": "#PASSWORD\n#DELAY1000\n{TAB}\n{TAB}\n{TAB}\n{ENTER}", //see explanation above
+            "execution-probability": 100, //after choosing a random target, the probability that a RDP to the target is opened
+            "delay-jitter": 50
 
-      },
+        },
       "Initial": "",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",

--- a/src/Ghosts.Client/Sample Timelines/Sftp.json
+++ b/src/Ghosts.Client/Sample Timelines/Sftp.json
@@ -20,13 +20,29 @@
   "TimeLineHandlers": [
     {
       "HandlerType": "Sftp",
-      "HandlerArgs": {
-        "TimeBetweenCommandsMax": 5000, //max,min between individual SFTP commands
-        "TimeBetweenCommandsMin": 1000,
-        "CredentialsFile": "<path to credentials>", //required, file path to a JSON file containing the SSH credentials
-        "UploadDirectory": "<path to uploads directory>", //optional, directory that contains files for upload, it not specified user Downloads directory is used
-        "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
-      },
+        "HandlerArgs": {
+            "TimeBetweenCommandsMax": 5000, //max,min between individual SFTP commands
+            "TimeBetweenCommandsMin": 1000,
+            // either Credentials File or Credentials must be defined
+            // if both Credentials and CredentialFile present, then Credentials takes precedence.
+            // Use Credentials arg to store Credentials directly in the timeline 
+            "CredentialsFile": "<path to credentials>", // file path to a JSON file containing the SSH credentials
+            "Credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "xx.xx.xx.xx_ahostname": {
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    },
+                    "yy.xx.xx.xx_ahostname": {
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
+            "UploadDirectory": "<path to uploads directory>", //optional, directory that contains files for upload, it not specified user Downloads directory is used
+            "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
+        },
       "Initial": "",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",

--- a/src/Ghosts.Client/Sample Timelines/Ssh.json
+++ b/src/Ghosts.Client/Sample Timelines/Ssh.json
@@ -25,14 +25,30 @@
   "TimeLineHandlers": [
     {
       "HandlerType": "Ssh",
-      "HandlerArgs": {
-        "CommandTimeout": 1000, //max time to wait for new input from an SSH command execution
-        "TimeBetweenCommandsMax": 5000, //max,min between individual SSH commands
-        "TimeBetweenCommandsMin": 1000,
-        "ValidExts": "txt;doc;png;jpeg", //used by [randomextension] reserved word, choose random extension from this list
-        "CredentialsFile": "d:\\ghosts_data\\ssh_creds.json", //required, file path to a JSON file containing the SSH credentials
-        "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
-      },
+        "HandlerArgs": {
+            "CommandTimeout": 1000, //max time to wait for new input from an SSH command execution
+            "TimeBetweenCommandsMax": 5000, //max,min between individual SSH commands
+            "TimeBetweenCommandsMin": 1000,
+            "ValidExts": "txt;doc;png;jpeg", //used by [randomextension] reserved word, choose random extension from this list
+            // either Credentials File or Credentials must be defined
+            // if both Credentials and CredentialFile present, then Credentials takes precedence.
+            // Use Credentials arg to store Credentials directly in the timeline 
+            "CredentialsFile": "<path to credentials>", // file path to a JSON file containing the SSH credentials
+            "Credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "xx.xx.xx.xx_ahostname": {
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    },
+                    "yy.xx.xx.xx_ahostname": {
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
+            "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
+        },
       "Initial": "",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",

--- a/src/Ghosts.Client/Sample Timelines/Wmi.json
+++ b/src/Ghosts.Client/Sample Timelines/Wmi.json
@@ -30,12 +30,30 @@
   "TimeLineHandlers": [
     {
       "HandlerType": "Wmi",
-      "HandlerArgs": {
-        "TimeBetweenCommandsMax": 5000, //max,min between individual WMI commands
-        "TimeBetweenCommandsMin": 1000,
-        "CredentialsFile": "<path to credentials>", //required, file path to a JSON file containing the WMI credentials
-        "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
-      },
+        "HandlerArgs": {
+            "TimeBetweenCommandsMax": 5000, //max,min between individual WMI commands
+            "TimeBetweenCommandsMin": 1000,
+            // either Credentials File or Credentials must be defined
+            // if both Credentials and CredentialFile present, then Credentials takes precedence.
+            // Use Credentials arg to store Credentials directly in the timeline 
+            "CredentialsFile": "<path to credentials>", // file path to a JSON file containing the SSH credentials
+            "Credentials": {
+                "Version": "1.0",
+                "Data": {
+                    "xx.xx.xx.xx_ahostname": {
+                        "domain":  "domainname"
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    },
+                    "yy.xx.xx.xx_ahostname": {
+                        "domain": "domainname",
+                        "username": "auser",
+                        "password": "b64encodedpw"
+                    }
+                }
+            },
+            "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
+        },
       "Initial": "",
       "UtcTimeOn": "00:00:00",
       "UtcTimeOff": "24:00:00",

--- a/src/ghosts.client.linux/Handlers/BlogHelper.cs
+++ b/src/ghosts.client.linux/Handlers/BlogHelper.cs
@@ -150,7 +150,7 @@ namespace ghosts.client.linux.handlers
         /// <param name="timelineEvent"></param>
         public void Execute(TimelineHandler handler, TimelineEvent timelineEvent)
         {
-            string credFname;
+            string credFname = null;
             string credentialKey = null;
 
 
@@ -215,12 +215,9 @@ namespace ghosts.client.linux.handlers
                         baseHandler.JitterFactor = Jitter.JitterFactorParse(value.ToString());
                     }
 
-
-                    credFname = handler.HandlerArgs["blog-credentials-file"].ToString();
-
                     if (handler.HandlerArgs.ContainsKey("blog-credentials-file"))
                     {
-
+                        credFname = handler.HandlerArgs["blog-credentials-file"].ToString();
                         try
                         {
                             _credentials = JsonConvert.DeserializeObject<Credentials>(System.IO.File.ReadAllText(credFname));
@@ -232,6 +229,28 @@ namespace ghosts.client.linux.handlers
                             Log.Error(e);
                             return;
                         }
+                    }
+
+                    if (handler.HandlerArgs.ContainsKey("blog-credentials"))
+                    {
+
+                        try
+                        {
+                            _credentials = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["blog-credentials"].ToString());
+                        }
+                        catch (System.Exception e)
+                        {
+                            Log.Trace($"Blog:: Error parsing blog credentials , blog browser action will not be executed.");
+                            baseHandler.BlogAbort = true;
+                            Log.Error(e);
+                            return;
+                        }
+                    }
+
+                    if (_credentials == null) {
+                        Log.Trace($"Blog:: No credentials specified in handler-args, blog browser action will not be executed.");
+                        baseHandler.BlogAbort = true;
+                        return;
                     }
 
                     //now parse the command args
@@ -297,7 +316,7 @@ namespace ghosts.client.linux.handlers
 
                     if (username == null || password == null)
                     {
-                        Log.Trace($"Blog:: The credential key {credentialKey} does not return a valid credential from file {credFname}, blog browser action will not be executed");
+                        Log.Trace($"Blog:: The credential key {credentialKey} does not return a valid credential, blog browser action will not be executed");
                         baseHandler.BlogAbort = true;
                         return;
                     }

--- a/src/ghosts.client.linux/Handlers/Sftp.cs
+++ b/src/ghosts.client.linux/Handlers/Sftp.cs
@@ -25,6 +25,7 @@ namespace ghosts.client.linux.handlers
                 CurrentSftpSupport = new SftpSupport();
                 if (handler.HandlerArgs != null)
                 {
+
                     if (handler.HandlerArgs.TryGetValue("CredentialsFile", out var v1))
                     {
                         try
@@ -40,7 +41,21 @@ namespace ghosts.client.linux.handlers
                             _log.Error(e);
                         }
                     }
-
+                    if (handler.HandlerArgs.TryGetValue("Credentials", out var credentials_arg))
+                    {
+                        try 
+                        {
+                            CurrentCreds = JsonConvert.DeserializeObject<Credentials>(credentials_arg.ToString());
+                        }
+                        catch (ThreadAbortException)
+                        {
+                            throw;  //pass up
+                        }
+                        catch (Exception e)
+                        {
+                            _log.Error(e);
+                        }
+                    }
                     if (handler.HandlerArgs.TryGetValue("TimeBetweenCommandsMax", out var v2))
                     {
                         try
@@ -93,7 +108,10 @@ namespace ghosts.client.linux.handlers
                     }
                 }
 
-
+                if (CurrentCreds == null) {
+                    _log.Error($"Sftp:: No credentials supplied, either CredentialsFile or Credentials must be supplied in handler args, exiting.");
+                    return;
+                }
 
                 if (handler.Loop)
                 {

--- a/src/ghosts.client.linux/Handlers/SharepointHelper.cs
+++ b/src/ghosts.client.linux/Handlers/SharepointHelper.cs
@@ -497,7 +497,7 @@ namespace ghosts.client.linux.handlers
         /// <param name="timelineEvent"></param>
         public void Execute(TimelineHandler handler, TimelineEvent timelineEvent)
         {
-            string credFname;
+            string credFname = null;
             string credentialKey = null;
 
 
@@ -570,11 +570,10 @@ namespace ghosts.client.linux.handlers
                         baseHandler.JitterFactor = Jitter.JitterFactorParse(v4.ToString());
                     }
 
-                    credFname = handler.HandlerArgs["sharepoint-credentials-file"].ToString();
-
+                    
                     if (handler.HandlerArgs.ContainsKey("sharepoint-credentials-file"))
                     {
-
+                        credFname = handler.HandlerArgs["sharepoint-credentials-file"].ToString();
                         try
                         {
                             _credentials = JsonConvert.DeserializeObject<Credentials>(System.IO.File.ReadAllText(credFname));
@@ -586,6 +585,28 @@ namespace ghosts.client.linux.handlers
                             Log.Error(e);
                             return;
                         }
+                    }
+
+                    if (handler.HandlerArgs.ContainsKey("sharepoint-credentials"))
+                    {
+
+                        try
+                        {
+                            _credentials = JsonConvert.DeserializeObject<Credentials>(handler.HandlerArgs["sharepoint-credentials"].ToString());
+                        }
+                        catch (System.Exception e)
+                        {
+                            Log.Trace($"Sharepoint:: Error parsing sharepoint credentials , sharepoint browser action will not be executed.");
+                            baseHandler.SharePointAbort = true;
+                            Log.Error(e);
+                            return;
+                        }
+                    }
+
+                    if (_credentials == null) {
+                        Log.Trace($"Sharepoint:: No credentials specified in handler-args, sharepoint browser action will not be executed.");
+                        baseHandler.SharePointAbort = true;
+                        return;
                     }
 
                     //now parse the command args
@@ -648,7 +669,7 @@ namespace ghosts.client.linux.handlers
 
                     if (username == null || password == null)
                     {
-                        Log.Trace($"Sharepoint:: The credential key {credentialKey} does not return a valid credential from file {credFname},   sharepoint browser action will not be executed");
+                        Log.Trace($"Sharepoint:: The credential key {credentialKey} does not return a valid credential,   sharepoint browser action will not be executed");
                         baseHandler.SharePointAbort = true;
                         return;
                     }

--- a/src/ghosts.client.linux/Handlers/Ssh.cs
+++ b/src/ghosts.client.linux/Handlers/Ssh.cs
@@ -50,6 +50,21 @@ namespace ghosts.client.linux.handlers
                             _log.Error(e);
                         }
                     }
+                    if (handler.HandlerArgs.TryGetValue("Credentials", out var credentials_arg))
+                    {
+                        try 
+                        {
+                            CurrentCreds = JsonConvert.DeserializeObject<Credentials>(credentials_arg.ToString());
+                        }
+                        catch (ThreadAbortException)
+                        {
+                            throw;  //pass up
+                        }
+                        catch (Exception e)
+                        {
+                            _log.Error(e);
+                        }
+                    }
                     if (handler.HandlerArgs.TryGetValue("ValidExts", out var v2))
                     {
                         try
@@ -102,7 +117,10 @@ namespace ghosts.client.linux.handlers
                     }
                 }
 
-
+                if (CurrentCreds == null) {
+                    _log.Error($"SSH:: No credentials supplied, either CredentialsFile or Credentials must be supplied in handler args, exiting.");
+                    return;
+                }
 
                 if (handler.Loop)
                 {

--- a/src/ghosts.client.linux/Infrastructure/Email/EmailConfiguration.cs
+++ b/src/ghosts.client.linux/Infrastructure/Email/EmailConfiguration.cs
@@ -50,7 +50,7 @@ public class EmailConfiguration
     public List<string> Attachments { get; }
     public EmailBodyType BodyType { get; }
 
-    public EmailConfiguration(IList<object> args)
+    public EmailConfiguration(IList<object> args, List<string> domainEmailList=null)
     {
         var settings = Program.Configuration.Email;
         var emailConfigArray = args;
@@ -74,9 +74,9 @@ public class EmailConfiguration
         //    this.From = $"{Environment.UserName}@{System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName}";
         //}
 
-        To = ParseEmail(emailConfigArray[1].ToString(), settings.RecipientsToMin, settings.RecipientsToMax);
-        Cc = ParseEmail(emailConfigArray[2].ToString(), settings.RecipientsCcMin, settings.RecipientsCcMax);
-        Bcc = ParseEmail(emailConfigArray[3].ToString(), settings.RecipientsBccMin, settings.RecipientsBccMax);
+        To = ParseEmail(emailConfigArray[1].ToString(), settings.RecipientsToMin, settings.RecipientsToMax, domainEmailList);
+        Cc = ParseEmail(emailConfigArray[2].ToString(), settings.RecipientsCcMin, settings.RecipientsCcMax, domainEmailList);
+        Bcc = ParseEmail(emailConfigArray[3].ToString(), settings.RecipientsBccMin, settings.RecipientsBccMax, domainEmailList);
 
         var emailContent = new EmailContentManager();
 
@@ -126,7 +126,7 @@ public class EmailConfiguration
         return $"Sending email from: {From} to: {string.Join(",", To)} cc: {string.Join(",", Cc)} bcc: {string.Join(",", Bcc)}";
     }
 
-    private static List<string> ParseEmail(string raw, int min, int max)
+    private static List<string> ParseEmail(string raw, int min, int max, List<string> domainEmailList=null)
     {
         var list = new List<string>();
         if (string.IsNullOrEmpty(raw)) return list;
@@ -152,7 +152,13 @@ public class EmailConfiguration
             else //build list
             {
                 //add domain
-                var emails = EmailListManager.GetDomainList();
+                var emails = domainEmailList;
+
+                if (emails == null)
+                {
+                    emails = EmailListManager.GetDomainList();
+                }
+                
 
                 for (var i = 0; i < numberOfRecipients; i++)
                     list.Add(emails.PickRandom());


### PR DESCRIPTION
 
- Bug fix: Added watching timeline.json to Orchestator for Linux

- Upward compatible changes - extended handlers to optionally read credentials and other
    info directly from timeline instead of external files to aid trafficgen
    changes from timeline update only.

    Affected handlers (changes involved adding one or more handler arg):
    Windows: SSH, FTP, WMI, RDP, BrowserSharepoint, BrowserBlog,
    BrowserOutlook, OutlookV2

    Linux: SFTP, SSH, BrowserSharepoint, BrowserBlog, BrowserOutlook

    All added handler args are optional.  See example timelines for doc.