### PR TITLE
fix: BrowserChrome service location, Cookie catching

### DIFF
--- a/src/Ghosts.Client.Windows/Ghosts.Client.csproj
+++ b/src/Ghosts.Client.Windows/Ghosts.Client.csproj
@@ -486,7 +486,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>5.3.2</Version>
+      <Version>6.0.5</Version>
     </PackageReference>
     <PackageReference Include="Quartz">
       <Version>3.8.1</Version>

--- a/src/Ghosts.Client.Windows/Handlers/BaseBrowserHandler.cs
+++ b/src/Ghosts.Client.Windows/Handlers/BaseBrowserHandler.cs
@@ -467,7 +467,16 @@ namespace Ghosts.Client.Handlers
                     case "POST":
                     case "PUT":
                     case "DELETE":
-                        Driver.Navigate().GoToUrl("about:blank");
+                        try
+                        {
+                            // Navigate to the root of the site so that we are not cross-origin, and cookies can be set correctly
+                            Driver.Navigate().GoToUrl(config.Uri.GetLeftPart(UriPartial.Authority));
+                        }
+                        catch
+                        {
+                            Driver.Navigate().GoToUrl("about:blank");
+                        }
+
                         var script = "var xhr = new XMLHttpRequest();";
                         script += $"xhr.open('{config.Method.ToUpper()}', '{config.Uri}', true);";
                         script += "xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');";

--- a/src/Ghosts.Client.Windows/Handlers/BrowserChrome.cs
+++ b/src/Ghosts.Client.Windows/Handlers/BrowserChrome.cs
@@ -286,7 +286,10 @@ namespace Ghosts.Client.Handlers
                 options.AddArguments($"--load-extension={Program.Configuration.ChromeExtensions}");
             }
             
-            var driver = new ChromeDriver(options);
+            var service = ChromeDriverService.CreateDefaultService(AppDomain.CurrentDomain.BaseDirectory);
+            service.HideCommandPromptWindow = true;
+            var driver = new ChromeDriver(service, options);
+
             driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
             return driver;
         }

--- a/src/Ghosts.Client.Windows/packages.config
+++ b/src/Ghosts.Client.Windows/packages.config
@@ -91,7 +91,7 @@
   <package id="NetOffice.Word.Net45" version="1.7.4.4" targetFramework="net461" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net461" />
-  <package id="NLog" version="5.0.1" targetFramework="net461" />
+  <package id="NLog" version="6.0.5" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net461" />
   <package id="Selenium.WebDriver" version="4.3.0" targetFramework="net461" />
   <package id="Selenium.WebDriver.ChromeDriver" version="103.0.5060.13400" targetFramework="net461" />


### PR DESCRIPTION
* update BrowserChrome selenium call to include local chromedriver. We are already packaging chromedriver.exe in with ghosts, so this just references an executable we already have. This prevents selenium from trying to reach out to the web and check for a newer chromedriver version, which prevented selenium from working in air- gapped (cyber range) environments.
* update BaseBrowser so POST/PUT/DELETE actions browse to the site in question before executing their action. This allows for combined browsing and HTTP actions, so that websites can be logged into and then browsed (ref https://github.com/cmu-sei/GHOSTS/discussions/517)

Other:
  * update NLog version in Ghosts.Client.Windows to match Domain
  * update build_windows.ps1 to allow multiple msbuild.exe locations