### PR TITLE
fix: email-content.csv parsing subject and id

### DIFF
--- a/src/Ghosts.Client.Universal/Infrastructure/Email/EmailConfiguration.cs
+++ b/src/Ghosts.Client.Universal/Infrastructure/Email/EmailConfiguration.cs
@@ -84,12 +84,14 @@ public class EmailConfiguration
 
         if (Subject.Equals("random", StringComparison.InvariantCultureIgnoreCase))
         {
+            Id = emailContent.Id;
             Subject = emailContent.Subject;
         }
 
         Body = emailConfigArray[5].ToString();
         if (Body.Equals("random", StringComparison.InvariantCultureIgnoreCase))
         {
+            Id = emailContent.Id;
             Body = emailContent.Body;
 
             Body +=

--- a/src/Ghosts.Client.Universal/Infrastructure/Email/EmailContent.cs
+++ b/src/Ghosts.Client.Universal/Infrastructure/Email/EmailContent.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using FileHelpers;
 using Ghosts.Domain.Code;
@@ -14,6 +15,7 @@ namespace Ghosts.Client.Universal.Infrastructure.Email;
 
 public class EmailContentManager
 {
+    public Guid Id { private set; get; }
     public string Subject { private set; get; }
     public string Body { private set; get; }
     public ClientConfiguration Configuration { private set; get; }
@@ -52,8 +54,25 @@ public class EmailContentManager
         var o = Content[_random.Next(0, total)];
         Configuration = Program.Configuration;
 
+        if (Guid.TryParse(o.Id, out var parsedGuid))
+        {
+            Id = parsedGuid;
+        }
+        else
+        {
+            Id = CreateGuidFromString(o.Id);
+        }
+
         Subject = ReplaceTokens(o.Subject);
         Body = Parse(o.Body);
+    }
+
+    private static Guid CreateGuidFromString(string s)
+    {
+        var bytes = Encoding.UTF8.GetBytes(s);
+        using var md5 = MD5.Create();
+        var hash = md5.ComputeHash(bytes);
+        return new Guid(hash);
     }
 
     public void LoadEmailFile()
@@ -121,7 +140,7 @@ public class EmailContentManager
             s.Replace(t, token.Value);
         }
 
-        var o = s.ToString().Replace("\\n", Environment.NewLine).Trim('"').Trim(' ').Trim('"');
+        var o = s.ToString().Replace("\\n", Environment.NewLine).Trim(' ');
         o = o.RemoveFirstLines(3);
 
         if (o.StartsWith("Subject:", StringComparison.InvariantCultureIgnoreCase))
@@ -172,8 +191,11 @@ public class EmailReplyManager
 [DelimitedRecord("|")]
 internal class EmailContent
 {
+    [FieldQuoted]
     public string Id { get; set; }
+    [FieldQuoted]
     public string Subject { get; set; }
+    [FieldQuoted]
     public string Body { get; set; }
 }
 

--- a/src/Ghosts.Client.Windows/Infrastructure/Email/EmailConfiguration.cs
+++ b/src/Ghosts.Client.Windows/Infrastructure/Email/EmailConfiguration.cs
@@ -88,14 +88,15 @@ public class EmailConfiguration
 
         if (this.Subject.Equals("random", StringComparison.InvariantCultureIgnoreCase))
         {
+            this.Id = emailContent.Id;
             this.Subject = emailContent.Subject;
         }
 
         this.Body = emailConfigArray[5].ToString();
         if (this.Body.Equals("random", StringComparison.InvariantCultureIgnoreCase))
         {
+            this.Id = emailContent.Id;
             this.Body = emailContent.Body;
-
             this.Body += GetFooter();
         }
 
@@ -154,7 +155,7 @@ public class EmailConfiguration
 
         var f = File.ReadAllText(ApplicationDetails.ConfigurationFiles.EmailsFooter);
         f = f.Replace("{{from}}", this.From);
-        f = f.Replace("{{now}}", DateTime.Now.ToLongDateString());
+        f = f.Replace("{{now}}", DateTime.Now.ToString()); // Use current culture
         f = f.Replace("{{id}}", this.Id.ToString());
         f = f.Replace("{{email}}", email);
         f = f.Replace("{{samaccountname}}", samAccountName);


### PR DESCRIPTION
* removes quotes that were showing up in email subjects when created/sent in outlook.
* adds parsing for the ID column in email-content. This attempts to read a GUID, and if it fails creates a GUID from the hash of the string.
* changes the format of printed {{now}} in the footer to include time (originally was only the date).