### PR TITLE
fix: powershell replace empty, trackables log timestamp

### DIFF
--- a/src/Ghosts.Client.Lite/src/Infrastructure/Services/LogWriter.cs
+++ b/src/Ghosts.Client.Lite/src/Infrastructure/Services/LogWriter.cs
@@ -19,6 +19,6 @@ public static class LogWriter
                 NullValueHandling = NullValueHandling.Ignore
             });
 
-        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow}|{o}");
+        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow:MM/dd/yyyy HH:mm:ss.fff}Z|{o}");
     }
 }

--- a/src/Ghosts.Client.Universal/Handlers/BaseHandler.cs
+++ b/src/Ghosts.Client.Universal/Handlers/BaseHandler.cs
@@ -90,6 +90,6 @@ public abstract class BaseHandler : IHandler
                 NullValueHandling = NullValueHandling.Ignore
             });
 
-        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow}|{o}");
+        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow:MM/dd/yyyy HH:mm:ss.fff}Z|{o}");
     }
 }

--- a/src/Ghosts.Client.Windows/Handlers/BaseHandler.cs
+++ b/src/Ghosts.Client.Windows/Handlers/BaseHandler.cs
@@ -41,7 +41,7 @@ namespace Ghosts.Client.Handlers
                     NullValueHandling = NullValueHandling.Ignore
                 });
 
-            _timelineLog.Info($"TIMELINE|{DateTime.UtcNow:MM/dd/yyyy hh:mm:ss tt}|{o}");
+            _timelineLog.Info($"TIMELINE|{DateTime.UtcNow:MM/dd/yyyy HH:mm:ss.fff}Z|{o}");
 
         }
 

--- a/src/Ghosts.Client.Windows/Handlers/PowerShell.cs
+++ b/src/Ghosts.Client.Windows/Handlers/PowerShell.cs
@@ -96,15 +96,14 @@ namespace Ghosts.Client.Handlers
 
         public void Command(TimelineHandler handler, TimelineEvent timelineEvent, string command)
         {
-            var replacements = handler.HandlerArgs["replace"];
-
+            var replacements = handler.HandlerArgs.ContainsKey("replace") ? handler.HandlerArgs["replace"] : new JArray();
             foreach (var replacement in JArray.FromObject(replacements))
             {
                 foreach (var o in replacement)
                 {
-                    command = Regex.Replace(command, "{" + ((JProperty)o).Name.ToString() + "}", ((Newtonsoft.Json.Linq.JArray)((JProperty)o).Value).PickRandom().ToString());
+                    command = Regex.Replace(command, "{" + ((JProperty) o).Name.ToString() + "}",
+                        ((Newtonsoft.Json.Linq.JArray) ((JProperty) o).Value).PickRandom().ToString());
                 }
-
             }
 
             var results = Command(command);


### PR DESCRIPTION
* powershell handler now continues gracefully if the handerArg's replace key is not set.
* trackables logging now includes fractional seconds and 'Z' to denote UTC timezone

** I have not tested this yet**