### PR TITLE
Infrastructure: Hardening WebRequestReader against null-identity crashes

### DIFF
--- a/src/Ghosts.Api.Tests/Ghosts.Api.Tests.csproj
+++ b/src/Ghosts.Api.Tests/Ghosts.Api.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ghosts.Api\Ghosts.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Ghosts.Api.Tests/UnitTest1.cs
+++ b/src/Ghosts.Api.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace Ghosts.Api.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}

--- a/src/Ghosts.Api.Tests/WebRequestReaderTests.cs
+++ b/src/Ghosts.Api.Tests/WebRequestReaderTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Http;
+using Ghosts.Api.Infrastructure;
+using Xunit;
+
+namespace Ghosts.Api.Tests;
+
+public class WebRequestReaderTests
+{
+    [Fact]
+    public void GetMachine_MissingHeaders_ShouldHandleGracefully()
+    {
+        // ARRANGE: A context with absolutely no identity headers
+        var context = new DefaultHttpContext(); 
+
+        // ACT
+        // On the virgin code, this line will trigger the ArgumentNullException 
+        // (and eventually a NullReferenceException).
+        var result = WebRequestReader.GetMachine(context);
+
+        // ASSERT: We expect a valid object back, even if fields are null
+        Assert.NotNull(result);
+    }
+}

--- a/src/Ghosts.Api/Infrastructure/WebRequestReader.cs
+++ b/src/Ghosts.Api/Infrastructure/WebRequestReader.cs
@@ -12,6 +12,7 @@ namespace Ghosts.Api.Infrastructure
     public static partial class WebRequestReader
     {
         private static readonly Logger _log = LogManager.GetCurrentClassLogger();
+
         public static Machine GetMachine(HttpContext context)
         {
             try
@@ -30,10 +31,11 @@ namespace Ghosts.Api.Infrastructure
                     StatusUp = Machine.UpDownStatus.Up
                 };
 
-                m.Name = m.Name.ToLower();
-                m.FQDN = m.FQDN.ToLower();
-                m.Host = m.Host.ToLower();
-                m.ResolvedHost = m.ResolvedHost.ToLower();
+                // Defensive hardening: Ensure transformations don't crash on missing headers
+                m.Name = m.Name?.ToLower();
+                m.FQDN = m.FQDN?.ToLower();
+                m.Host = m.Host?.ToLower();
+                m.ResolvedHost = m.ResolvedHost?.ToLower();
 
                 return m;
             }
@@ -46,6 +48,12 @@ namespace Ghosts.Api.Infrastructure
 
         private static string CheckIfBase64Encoded(string raw)
         {
+            // Guard clause: Prevent ArgumentNullException in the Regex engine
+            if (string.IsNullOrEmpty(raw))
+            {
+                return raw;
+            }
+
             var reg = MyRegex();
             return reg.IsMatch(raw) ? Base64Encoder.Base64Decode(raw) : raw;
         }


### PR DESCRIPTION
## Summary
This PR introduces defensive hardening to the `WebRequestReader` infrastructure. This fix ensures the GHOSTS API remains resilient under 'noisy' network conditions where identity headers may be stripped.

## The Narrative (Red/Green Testing)
1. **Reproduction (Red):** Initialized `Ghosts.Api.Tests` to capture `ArgumentNullException` and `NullReferenceException` from missing headers.
2. **Resolution (Green):** Implemented null-safety guards and conditional transformations (`?.`). 

## Impact
* **DORA Metric:** Reduces **Change Failure Rate** in production.
