### PR TITLE
ci: use github release

### DIFF
--- a/.github/workflows/client-lite.yml
+++ b/.github/workflows/client-lite.yml
@@ -1,13 +1,8 @@
 name: Client Lite
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'src/Ghosts.Client.Lite/**'
-      - 'src/Ghosts.Domain/**'
-      - '.github/workflows/client-lite.yml'
   pull_request:
+    branches: [master]
     paths:
       - 'src/Ghosts.Client.Lite/**'
       - 'src/Ghosts.Domain/**'

--- a/.github/workflows/client-universal.yml
+++ b/.github/workflows/client-universal.yml
@@ -1,13 +1,8 @@
 name: Client Universal
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'src/Ghosts.Client.Universal/**'
-      - 'src/Ghosts.Domain/**'
-      - '.github/workflows/client-universal.yml'
   pull_request:
+    branches: [master]
     paths:
       - 'src/Ghosts.Client.Universal/**'
       - 'src/Ghosts.Domain/**'

--- a/.github/workflows/client-windows.yml
+++ b/.github/workflows/client-windows.yml
@@ -1,13 +1,8 @@
 name: Client Windows
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'src/Ghosts.Client.Windows/**'
-      - 'src/Ghosts.Domain/**'
-      - '.github/workflows/client-windows.yml'
   pull_request:
+    branches: [master]
     paths:
       - 'src/Ghosts.Client.Windows/**'
       - 'src/Ghosts.Domain/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,21 +2,23 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
-  release-please:
+  create-release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          # release-please-config.json at root controls release-type,
-          # extra-files (all version locations), and changelog settings.
-          # .release-please-manifest.json is managed by the action itself.
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "Release ${{ github.ref_name }}" \
+            --generate-notes


### PR DESCRIPTION
Fixing #606. **No PAT required, uses integrated `GITHUB_TOKEN`**

- On any push/PR touching src/Ghosts.Api/**, src/Ghosts.Domain/**, or src/Ghosts.Animator/** → Docker image built and pushed to ghcr.io/<owner>/ghosts/api tagged with branch/commit SHA
- On any PR touching src/Ghosts.Frontend/** → Docker image built and pushed to ghcr.io/<owner>/ghosts/frontend
- On any PR touching src/Ghosts.Pandora/** → Docker image built and pushed to ghcr.io/<owner>/ghosts/pandora
- On any PR to touching src/Ghosts.Client.Universal/** → dotnet build CI check
- On any PR to touching src/Ghosts.Client.Windows/** → MSBuild CI check (x32 + x64)
- On any PR touching src/Ghosts.Client.Lite/** → dotnet build CI check
- On push to master touching docs/** or mkdocs.yml → MkDocs deployed to GitHub Pages
- On v* tag push → GitHub Release created with auto-generated notes; this triggers all 6 workflows above to additionally build Docker images tagged with the semver version, and publish + upload binary zip artifacts (Universal ×4 RIDs, Windows x32/x64, Lite ×4  RIDs) to the release

**I still do not have a solution for managing version numbers in files.**