### PR TITLE
fix(api): rotate ghosts.api.log to bound disk usage

### DIFF
--- a/src/Ghosts.Api/nlog.config
+++ b/src/Ghosts.Api/nlog.config
@@ -4,7 +4,16 @@
       internalLogLevel="Error" internalLogFile="nlog-internal.log">
 
     <targets>
-        <target name="logfile" xsi:type="File" fileName="logs/ghosts.api.log" layout="${Date}|${callsite}|${message}" />
+        <!-- Roll the api log at 50 MB, keep 3 archives (~200 MB total cap). -->
+        <target name="logfile" xsi:type="File"
+                fileName="logs/ghosts.api.log"
+                layout="${Date}|${callsite}|${message}"
+                archiveFileName="logs/ghosts.api.{#}.log"
+                archiveAboveSize="52428800"
+                archiveNumbering="Sequence"
+                maxArchiveFiles="3"
+                concurrentWrites="false"
+                keepFileOpen="true" />
         <target name="console" xsi:type="Console" />
     </targets>
     <rules>


### PR DESCRIPTION
## What

`src/Ghosts.Api/nlog.config` declares a `File` target for
`ghosts.api.log` with no rotation attributes, so the file grows
unbounded.

## Why

Under sustained client load (a single agent running a content-fetching
timeline at Trace level) the log reached several GB in a few hours and
filled `/var/lib/docker` on the host — `logs/` inside the api container
lives in the writable layer rather than a mounted volume, so unbounded
growth consumes the docker root filesystem directly. The container
became unhealthy and the docker daemon started failing writes.

## Fix

Add NLog's standard size-based rolling:

- `archiveAboveSize="52428800"` — roll at 50 MB
- `maxArchiveFiles="3"` — keep 3 archives
- `archiveNumbering="Sequence"` — NLog appends a zero-padded sequence
  number to the basename, so archives appear alongside the live file
  as `ghosts.api_01.log`, `ghosts.api_02.log`, etc.
- `concurrentWrites="false"` + `keepFileOpen="true"` — NLog's
  recommended settings for a single-process server; faster and makes
  rotation reliable

Hard cap on disk: ~208 MB per api container (live + 3 archives at ~52 MB
each; NLog rotates after the live file exceeds the threshold). Plenty
of headroom for debugging windows; can't fill a disk.

## Tests

Config-only change; no unit test coverage applicable. Verified
end-to-end on our deployment: under load from two clients running a
content-fetching timeline at Trace level, the live file crossed 50 MB
at ~4.8 MB/min and NLog rolled it to `ghosts.api_01.log` (52 MB) while
starting a fresh `ghosts.api.log`. Pruning at `maxArchiveFiles="3"`
expected to verify on subsequent rolls. Attributes also confirmed
present in the running container via `docker exec ghosts-api cat
/app/nlog.config`.

## PR checklist

- [x] Builds without errors (`dotnet build src/Ghosts.Api/Ghosts.Api.csproj`)
- [x] No hardcoded credentials, secrets, or environment-specific paths
- [x] No code change, no migration needed
- [x] No user-facing behaviour change — file path and layout unchanged
- [x] Tested locally (config validates, container starts cleanly)

## AI use

Patched with Claude Code assistance. The change is a small set of NLog
attributes; I've read the diff and can explain every attribute in
review.
