### PR TITLE
fix(client): await HealthManager.Check() so HEALTH lines carry ResultHealth, not Task wrapper

### DIFF
--- a/src/Ghosts.Client.Universal/Health/Check.cs
+++ b/src/Ghosts.Client.Universal/Health/Check.cs
@@ -76,7 +76,10 @@ namespace Ghosts.Client.Universal.Health
             {
                 try
                 {
-                    var r = HealthManager.Check(config);
+                    // Block on the async Check() so we serialize the resolved
+                    // ResultHealth, not the Task wrapper. RunEx runs on its
+                    // own thread (no sync context), so GetResult is safe here.
+                    var r = HealthManager.Check(config).GetAwaiter().GetResult();
 
                     var o = JsonConvert.SerializeObject(r,
                         Formatting.None,

--- a/src/Ghosts.Client.Windows/Health/Check.cs
+++ b/src/Ghosts.Client.Windows/Health/Check.cs
@@ -71,7 +71,10 @@ public class Check
         {
             try
             {
-                var r = HealthManager.Check(config);
+                // Block on the async Check() so we serialize the resolved
+                // ResultHealth, not the Task wrapper. RunEx runs on its
+                // own thread (no sync context), so GetResult is safe here.
+                var r = HealthManager.Check(config).GetAwaiter().GetResult();
 
                 var o = JsonConvert.SerializeObject(r,
                     Formatting.None,


### PR DESCRIPTION
## What

`Ghosts.Client.Universal/Health/Check.cs` (line 79) and
`Ghosts.Client.Windows/Health/Check.cs` (line 74) call
`HealthManager.Check(config)` and JSON-serialize the result without
awaiting:

```csharp
var r = HealthManager.Check(config);

var o = JsonConvert.SerializeObject(r, ...);

_healthLog.Info($"HEALTH|{DateTime.UtcNow}|{o}");
```

Since the commit `ef8e8710` ("updates webclient to httpclient",
2025-05-31), `HealthManager.Check` has the signature
`public static async Task<ResultHealth> Check(ConfigHealth config)`,
so `r` is a `Task<ResultHealth>`, not a `ResultHealth`. Both call sites
were missed in the sync→async conversion.

## Why

Two failure modes, both silent:

1. **Task not yet completed at serialize time.** Newtonsoft.Json hits a
   self-reference loop inside the async state machine and throws:

   > Newtonsoft.Json.JsonSerializationException: Self referencing loop
   > detected for property 'Task' with type
   > `AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[...]`.
   > Path 'StateMachine.<>t__builder'.

   The exception is caught by the surrounding `try/catch` and logged
   at `_log.Debug` only, so the HEALTH line is dropped without anything
   visible at default log levels. Repeats every `config.Sleep`.

2. **Task has completed.** Newtonsoft serializes the `Task` wrapper
   shape:

   ```json
   {
     "Result": { "Internet": false, "Permissions": false,
                 "ExecutionTime": 14, "Errors": [...],
                 "LoggedOnUsers": ["dev"],
                 "Stats": {"Memory": ..., "Cpu": ..., "DiskSpace": ...} },
     "Id": 1, "Status": 5, "IsCanceled": false, "IsCompleted": true,
     "IsCompletedSuccessfully": true, "CreationOptions": 0,
     "IsFaulted": false
   }
   ```

   The server-side parser at
   `Ghosts.Api/Infrastructure/Services/QueueSyncService.cs` (`case
   "HEALTH":`) reads `data.Internet`, `data.Permssions`,
   `data.LoggedOnUsers`, `data.Stats`, etc. at the **top level**.
   None of those exist at the top level here (they are inside
   `Result`), so a `HistoryHealth` row is written with every field
   blank/null.

Net effect: `HealthIsEnabled: true` produces no usable health telemetry
in either mode. The feature has been silently dead for ~12 months.

## Fix

One line per client. Block on the async `Check()` so we serialize the
resolved `ResultHealth`, not the `Task` wrapper:

```csharp
-                    var r = HealthManager.Check(config);
+                    var r = HealthManager.Check(config).GetAwaiter().GetResult();
```

`RunEx` is invoked on a dedicated `new Thread(...)` with no sync
context, so `.GetAwaiter().GetResult()` cannot deadlock here. The loop's
next call is `Thread.Sleep(config.Sleep)` anyway, so blocking for the
task to complete is the desired behaviour.

The same buggy pattern, same one-line fix, applies to both
`Ghosts.Client.Universal/Health/Check.cs` and
`Ghosts.Client.Windows/Health/Check.cs`.

## Tests

Verified end-to-end on our deployment with a single `client-linux-01`
agent against a stock `ghosts-api`.

**Before patch:**

- Agent log (`logs/app_*.log`) shows the JsonSerializationException
  every 60 s.
- `GET /api/machines/{id}/health` returns an empty array.

**After patch (Universal DLL rebuilt from this branch, dropped in
place, agent restarted):**

- Agent log shows no `JsonSerializationException` and no
  "Self referencing loop" lines.
- `GET /api/machines/{id}/health` returns 10+ rows within minutes,
  with the expected top-level fields populated:

```json
{
  "id": 12,
  "machineId": "d146726e-...",
  "createdUtc": "2026-05-13T19:40:16",
  "internet": true,
  "permissions": null,
  "executionTime": 26,
  "errors": "",
  "loggedOnUsers": "dev",
  "stats": "{\"Memory\":910762000.0,\"Cpu\":72127000.0,\"DiskSpace\":0.19919026}"
}
```

(`permissions` is `null` because `MachineHealth.Run` on Linux does not
compute `Permissions`; that is a separate, pre-existing behaviour
unrelated to this PR.)

The Windows client has the byte-identical pattern, fixed identically.
Cross-compiling `Ghosts.Client.csproj` (`TargetFramework=net462`) from
a Linux SDK image needs the .NET Framework Developer Pack and so was
not built here, but the change is mechanical.

No unit test added — neither client project ships with a test
project today, and the fix targets a private static method inside an
infinite `while (true)` loop driven by `FileSystemWatcher`, which is
hard to exercise cleanly without one. Happy to add coverage if the
maintainers would like, but did not want to bundle test-project
scaffolding into a single-concern PR.

## PR checklist

- [x] Builds without errors (`dotnet build src/Ghosts.Client.Universal/Ghosts.Client.Universal.csproj`)
- [x] No hardcoded credentials, secrets, or environment-specific paths
- [x] Behavioural change verified end-to-end on a live agent + api
- [x] No public API change; no config change
- [x] Fix applied symmetrically to both client variants

## AI use

Investigated and patched with Claude Code assistance. The diagnosis
path (observe `JsonSerializationException` in the agent log, capture
the slipped-through Task-wrapper JSON, `git -S` the introducing commit,
confirm only two call sites in the tree) was done in collaboration; the
fix itself is one line per file and I have read both diffs.
