### PR TITLE
Fixed problem in Watcher that was spawning infinite awaiters

### DIFF
--- a/src/Ghosts.Client.Universal/Handlers/Watcher.cs
+++ b/src/Ghosts.Client.Universal/Handlers/Watcher.cs
@@ -37,9 +37,9 @@ internal class Watcher(Timeline entireTimeline, TimelineHandler timelineHandler,
                 }
             }
 
-            while (!Token.IsCancellationRequested)
+            while (true)
             {
-                await Task.Delay(2000, Token);
+                if (Token.WaitHandle.WaitOne(2000)) Token.ThrowIfCancellationRequested();  //default
             }
         }
         catch (OperationCanceledException)


### PR DESCRIPTION
This is a one line bug fix in Universal/Watcher.cs where the `await Task.Delay()`  in the wait loop is replaced by `Token.WaitHandle.WaitOne()` as the loop was continually spawing awaiters can causing the Watcher task to crash.

The new loop exits as the same way as the old loop does, when the task is canceled.

I missed this in my last PR - I had this fix in my local code but when I rebased on top of the latest CMU changes the fix got lost. 


