### PR TITLE
Fix DateTime dependence on regional format

### DIFF
--- a/src/Ghosts.Client.Lite/src/Infrastructure/Services/LogWriter.cs
+++ b/src/Ghosts.Client.Lite/src/Infrastructure/Services/LogWriter.cs
@@ -19,6 +19,6 @@ public static class LogWriter
                 NullValueHandling = NullValueHandling.Ignore
             });
 
-        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow:MM/dd/yyyy HH:mm:ss.fff}Z|{o}");
+        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow.ToString("MM/dd/yyyy HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture)}Z|{o}");
     }
 }

--- a/src/Ghosts.Client.Universal/Handlers/BaseHandler.cs
+++ b/src/Ghosts.Client.Universal/Handlers/BaseHandler.cs
@@ -100,7 +100,7 @@ public abstract class BaseHandler : IHandler
                 NullValueHandling = NullValueHandling.Ignore
             });
 
-        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow:MM/dd/yyyy HH:mm:ss.fff}Z|{o}");
+        _timelineLog.Info($"TIMELINE|{DateTime.UtcNow.ToString("MM/dd/yyyy HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture)}Z|{o}");
     }
 
     public bool CheckProbabilityVar(string name, int value)

--- a/src/Ghosts.Client.Universal/Health/Check.cs
+++ b/src/Ghosts.Client.Universal/Health/Check.cs
@@ -88,7 +88,7 @@ namespace Ghosts.Client.Universal.Health
                             NullValueHandling = NullValueHandling.Ignore
                         });
 
-                    _healthLog.Info($"HEALTH|{DateTime.UtcNow}|{o}");
+                    _healthLog.Info($"HEALTH|{DateTime.UtcNow.ToString("MM/dd/yyyy HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture)}Z}|{o}");
 
 
                     Thread.Sleep(config.Sleep);

--- a/src/Ghosts.Client.Windows/Handlers/BaseHandler.cs
+++ b/src/Ghosts.Client.Windows/Handlers/BaseHandler.cs
@@ -41,7 +41,7 @@ namespace Ghosts.Client.Handlers
                     NullValueHandling = NullValueHandling.Ignore
                 });
 
-            _timelineLog.Info($"TIMELINE|{DateTime.UtcNow:MM/dd/yyyy HH:mm:ss.fff}Z|{o}");
+            _timelineLog.Info($"TIMELINE|{DateTime.UtcNow.ToString("MM/dd/yyyy HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture)}Z|{o}");
 
         }
 
@@ -50,7 +50,7 @@ namespace Ghosts.Client.Handlers
             if (payload != null)
             {
                 payload = payload.Replace(Environment.NewLine, string.Empty);
-                _timelineLog.Info($"WEBHOOKCREATE|{DateTime.UtcNow:MM/dd/yyyy hh:mm:ss tt}|{payload}");
+                _timelineLog.Info($"WEBHOOKCREATE|{DateTime.UtcNow.ToString("MM/dd/yyyy hh:mm:ss tt", System.Globalization.CultureInfo.InvariantCulture)}|{payload}");
             }
         }
 

--- a/src/Ghosts.Client.Windows/Health/Check.cs
+++ b/src/Ghosts.Client.Windows/Health/Check.cs
@@ -84,7 +84,7 @@ public class Check
                         NullValueHandling = NullValueHandling.Ignore
                     });
 
-                _healthLog.Info($"HEALTH|{DateTime.UtcNow}|{o}");
+                _healthLog.Info($"HEALTH|{DateTime.UtcNow.ToString("MM/dd/yyyy HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture)}Z}|{o}");
 
 
                 Thread.Sleep(config.Sleep);


### PR DESCRIPTION
Converting DateTime to string is dependent on regional format, which can lead to formats the API Server cannot parse, such as
```
ghosts-api    | 2026-05-19 11:18:36.1407|TRACE|ghosts.api.Infrastructure.Services.QueueSyncService|Bad line: System.FormatException: String '19.05.2026 11:14:21' was not recognized as a valid DateTime.
ghosts-api    |    at System.DateTimeParse.Parse(ReadOnlySpan`1 s, DateTimeFormatInfo dtfi, DateTimeStyles styles)
ghosts-api    |    at System.Convert.ToDateTime(String value)
ghosts-api    |    at ghosts.api.Infrastructure.Services.QueueSyncService.ProcessMachine(IServiceScope scope, ApplicationDbContext context, MachineQueueEntry item) in /app/Ghosts.Api/Infrastructure/Services/QueueSyncService.cs:line 192 - HEALTH|19.05.2026 11:14:21|{"Internet":true,"Permissions":false,"ExecutionTime":1390,"Errors":[],"LoggedOnUsers":["***"],"Stats":{"Memory":0.765143633,"Cpu":57.2688942,"DiskSpace":0.761365533}}
```

The timeline with the format string `MM/dd/yyyy HH:mm:ss.fff` does not error, but without the `InvariantCulture` the format string can become `05.19.2026 14:13:19.746`, so the format may be interpreted unexpectedly with some other regional setting.

Tested on Windows 11 26200.8457