### PR TITLE
fix: universal browser cross-origin requests and local driver

### DIFF
--- a/src/Ghosts.Client.Universal/Handlers/BrowserBase.cs
+++ b/src/Ghosts.Client.Universal/Handlers/BrowserBase.cs
@@ -846,7 +846,15 @@ public abstract class BaseBrowserHandler(Timeline timeline, TimelineHandler hand
                 case "POST":
                 case "PUT":
                 case "DELETE":
-                    Driver.Navigate().GoToUrl("about:blank");
+                    try
+                    {
+                        // Navigate to the root of the site so that we are not cross-origin, and cookies can be set correctly
+                        Driver.Navigate().GoToUrl(config.Uri.GetLeftPart(UriPartial.Authority));
+                    }
+                    catch
+                    {
+                        Driver.Navigate().GoToUrl("about:blank");
+                    }
                     var script = "var xhr = new XMLHttpRequest();";
                     script += $"xhr.open('{config.Method.ToUpperInvariant()}', '{config.Uri}', true);";
                     script += "xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');";

--- a/src/Ghosts.Client.Universal/Handlers/BrowserFirefox.cs
+++ b/src/Ghosts.Client.Universal/Handlers/BrowserFirefox.cs
@@ -318,7 +318,10 @@ public class BrowserFirefox(Timeline timeline, TimelineHandler handler, Cancella
 
         try
         {
-            driver = new FirefoxDriver(options);
+            // Pin geckodriver to the application base directory (packaged by Selenium.WebDriver.GeckoDriver)
+            // so Selenium does not reach out to the network for a driver - required for air-gapped use.
+            var service = FirefoxDriverService.CreateDefaultService(AppDomain.CurrentDomain.BaseDirectory);
+            driver = new FirefoxDriver(service, options);
         }
         catch
         {

--- a/src/Ghosts.Client.Windows/Ghosts.Client.csproj
+++ b/src/Ghosts.Client.Windows/Ghosts.Client.csproj
@@ -349,7 +349,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Ghosts.Domain\ghosts.domain.csproj">
+    <ProjectReference Include="..\Ghosts.Domain\Ghosts.Domain.csproj">
       <Project>{3bcae63e-7914-4bd3-a751-bf69820ff1be}</Project>
       <Name>ghosts.domain</Name>
     </ProjectReference>


### PR DESCRIPTION
Ports the #568 browser fixes to the Universal client:

- POST/PUT/DELETE now navigate to the site authority before the XHR (was `about:blank`, which is cross-origin and gets blocked).
- The Firefox driver is pinned to the app base directory so Selenium doesn't reach out for a driver (air-gapped use).