### PR TITLE
fix: correct Ghosts.Domain reference casing in windows client

### DIFF
--- a/src/Ghosts.Client.Windows/Ghosts.Client.csproj
+++ b/src/Ghosts.Client.Windows/Ghosts.Client.csproj
@@ -349,7 +349,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Ghosts.Domain\ghosts.domain.csproj">
+    <ProjectReference Include="..\Ghosts.Domain\Ghosts.Domain.csproj">
       <Project>{3bcae63e-7914-4bd3-a751-bf69820ff1be}</Project>
       <Name>ghosts.domain</Name>
     </ProjectReference>


### PR DESCRIPTION
The Windows client referenced `..\Ghosts.Domain\ghosts.domain.csproj`; the file is `Ghosts.Domain.csproj`. This fails on case-sensitive (Linux) filesystems. Same fix as #562 for the Universal client.