### PR TITLE
Remove Thread.Sleep from Ghosts.Client.Universal/Handlers.Wmi.cs

### DIFF
--- a/src/Ghosts.Client.Universal/Handlers/Wmi.cs
+++ b/src/Ghosts.Client.Universal/Handlers/Wmi.cs
@@ -111,8 +111,10 @@ public class Wmi(Timeline entireTimeline, TimelineHandler timelineHandler, Cance
             Token.ThrowIfCancellationRequested();
             WorkingHours.Is(Handler);
 
-            if (timelineEvent.DelayBeforeActual > 0)
-                Thread.Sleep(timelineEvent.DelayBeforeActual);
+            if (timelineEvent.DelayBeforeActual > 0){
+                if (Token.WaitHandle.WaitOne(timelineEvent.DelayBeforeActual)) Token.ThrowIfCancellationRequested();
+
+            }
 
             _log.Trace($"WMI Command: {timelineEvent.Command} with delay after of {timelineEvent.DelayAfterActual}");
 
@@ -124,12 +126,15 @@ public class Wmi(Timeline entireTimeline, TimelineHandler timelineHandler, Cance
                     {
                         ExecuteWmi(timelineEvent, cmd.ToString());
                     }
-                    Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayAfterActual, _jitterFactor));
+                    if (timelineEvent.DelayAfterActual > 0) {
+                        if (Token.WaitHandle.WaitOne(Jitter.JitterFactorDelay(timelineEvent.DelayAfterActual, _jitterFactor))) Token.ThrowIfCancellationRequested();
+                    }
                     break;
             }
 
-            if (timelineEvent.DelayAfterActual > 0)
-                Thread.Sleep(Jitter.JitterFactorDelay(timelineEvent.DelayAfterActual, _jitterFactor));
+            if (timelineEvent.DelayAfterActual > 0) {
+                if (Token.WaitHandle.WaitOne(Jitter.JitterFactorDelay(timelineEvent.DelayAfterActual, _jitterFactor))) Token.ThrowIfCancellationRequested();
+            }
         }
     }
 


### PR DESCRIPTION
This is a small PR that cleans up `Ghosts.Client.Universal/Handlers.Wmi.cs` to replace `Thread.Sleep` with `Token.WaitHandle.Waitone`.    This was missed in the initial PR for this code.

