### PR TITLE
Updated handler docs for embedded credentials support

### DIFF
--- a/docs/core/handlers/blog_helper.md
+++ b/docs/core/handlers/blog_helper.md
@@ -1,13 +1,14 @@
 # Blog Helper Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/BrowserChromeBlogDrupal.json>
 
 The 'blog' command for a browser handler allows browse/deletion/upload/reply from a blog site.
 
 The handlerArgs for the blog command are:
 
 - "blog-credentials-file": `json credentials file path`,  required, credentials file, see SSh.json sample handler for format
+- "blog-credentials": embedded credentials instead of an external file, see documentation below.
 - "blog-deletion-probability": <0-100 integer>, default  0, probability to delete a blog post
 - "blog-upload-probability": <0-100 integer>, default 0 , probability to upload a blog post
 - "blog-reply-probability": <0-100 integer>, default 0 , probability to reply to a random blog post
@@ -87,3 +88,63 @@ The timeline configuration looks like this:
   ]
 }
 ```
+
+Instead of using an external credentials file specified by the `HandlerArgs[blog-credentials-file]` key, the credentials can be placed directly in the timeline using the `HandlerArgs[blog-credentials]` key as shown below:
+
+```json
+{
+  "Status": "Run",
+  "TimeLineHandlers": [
+    {
+      "HandlerType": "BrowserChrome",
+      "HandlerArgs": {
+        "isheadless": "false",
+        "blockimages": "true",
+        "blockstyles": "true",
+        "blockflash": "true",
+        "blockscripts": "true",
+        "stickiness": 75,
+        "stickiness-depth-min": 5,
+        "stickiness-depth-max": 10000,
+        "incognito": "true",
+        "blog-credentials": {
+          "Version": "1.0",
+          "Data": {
+            "credkey1": {"username":"user1","password":"pw1base64"},
+            "credkey2": {"username":"user2","password":"pw2base64"},
+              ....
+             "credkeyN": {"username":"userN","password":"pwNbase64"},
+          }
+        },
+        "blog-deletion-probability": 0,
+        "blog-upload-probability": 0,
+        "blog-browse-probability": 0,
+        "blog-reply-probability": 100,
+        "blog-version": "drupal"
+
+      },
+      "Initial": "about:blank",
+      "UtcTimeOn": "00:00:00",
+      "UtcTimeOff": "24:00:00",
+      "Loop": "True",
+      "TimeLineEvents": [
+        {
+          "Command": "blog",
+          "CommandArgs": [
+            "site:http://www.netexhsv.com:8080",
+            "credentialKey:credkey1"
+          ],
+          "DelayAfter": 10000,
+          "DelayBefore": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+Placing the credentials directly in the timeline is a better approach if the GhostsApi server is used to update the timeline as this makes the timeline self-contained.
+
+
+
+

--- a/docs/core/handlers/browser.md
+++ b/docs/core/handlers/browser.md
@@ -2,8 +2,7 @@
 
 The browser handlers simulate realistic web browsing behavior using Firefox or Chrome. GHOSTS can control browser activities including page navigation, form interaction, file downloads, and more.
 
-???+ info "Sample Configurations"
-    Sample browser timelines are available in the [GHOSTS GitHub repository](https://github.com/cmu-sei/GHOSTS/tree/master/src/Ghosts.Client/Sample%20Timelines).
+Sample browser timelines are available in the [GHOSTS GitHub repository](https://github.com/cmu-sei/GHOSTS/tree/master/src/Ghosts.Client.Windows/Sample%20Timelines).
 
 ## Prerequisites
 

--- a/docs/core/handlers/clicks.md
+++ b/docs/core/handlers/clicks.md
@@ -1,7 +1,6 @@
 # Clicks Handler Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks)
+The sample configuration below is also available in the [GHOSTS GitHub repository](https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Clicks.json)
 
 The following is the format for a basic timeline handler:
 

--- a/docs/core/handlers/cmd.md
+++ b/docs/core/handlers/cmd.md
@@ -1,7 +1,6 @@
 # CMD Handler Configuration
 
-???+ info "Sample Configuration"
-    Sample command handler configurations are available in the [GHOSTS GitHub repository](https://github.com/cmu-sei/GHOSTS/tree/master/src/Ghosts.Client/Sample%20Timelines)
+Sample command handler configurations are available in the [GHOSTS GitHub repository](https://github.com/cmu-sei/GHOSTS/tree/master/src/Ghosts.Client.Windows/Sample%20Timelines)
 
 The CMD handler allows you to execute command-line operations as part of your NPC timeline. This can include running PowerShell scripts, batch files, or any command-line utilities available on the system.
 

--- a/docs/core/handlers/database.md
+++ b/docs/core/handlers/database.md
@@ -1,5 +1,7 @@
 # Database Handler Configuration
 
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Database.json>
+
 The database handler is used to perform insert, query, and delete operations to one or more MySql database servers. The configuration can be used specify a simplified schema with multiple databases, each with multiple tables, each table with multiple columns.
 
 When the handler is executed, a random database is chosen along with a random table from that database. This DB/Table is queried for row count, and if empty, 10 rows are generated as initial content.  If non-empty, either an insert operation (one row inserted), delete (first row is deleted), or query operation is performed (a maximum of `query-limit` rows are returned and written to the Ghosts log file).  The query starts at a random offset from within the rows.  If the `max-rows` parameter is non-zero then when this number of rows is reached a deletion operation is forced.

--- a/docs/core/handlers/excel.md
+++ b/docs/core/handlers/excel.md
@@ -1,7 +1,6 @@
 # Excel Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Excel.json>
 
 ```json
 {

--- a/docs/core/handlers/notepad.md
+++ b/docs/core/handlers/notepad.md
@@ -1,7 +1,6 @@
 # Notepad Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Notepad.json>
 
 There is currently only one supported command (random) which uses probabilities to write text.
 

--- a/docs/core/handlers/npc_system.md
+++ b/docs/core/handlers/npc_system.md
@@ -1,7 +1,6 @@
 # NPC System Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/NpcSystem.json>
 
 This is currently only used to turn the client on and off (where the client binary still runs, but does nothing).  It is not used to control the client's behavior as other handlers might do.
 

--- a/docs/core/handlers/outlook.md
+++ b/docs/core/handlers/outlook.md
@@ -1,7 +1,6 @@
 # Outlook Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Outlook.json>
 
 ```json
 {

--- a/docs/core/handlers/pidgin.md
+++ b/docs/core/handlers/pidgin.md
@@ -1,7 +1,6 @@
 # Pidgin Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Pidgin.json>
 
 Exercises a Pidgin client - tested with Pidgin 2.14.1 (libpurple 2.14.1) ane Centos 7.3 ejabberd server
 

--- a/docs/core/handlers/powerpoint.md
+++ b/docs/core/handlers/powerpoint.md
@@ -1,7 +1,6 @@
 # PowerPoint Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/PowerPoint.json>
 
 ```json
 {

--- a/docs/core/handlers/print.md
+++ b/docs/core/handlers/print.md
@@ -1,7 +1,6 @@
 # Printing Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Print.json>
 
 - Command is the printer to be used for printing (this must already be setup on the system).
 - CommandArgs is the path to the file to be printed.

--- a/docs/core/handlers/rdp.md
+++ b/docs/core/handlers/rdp.md
@@ -1,12 +1,11 @@
 # Remote Desktop Protocol (RDP) Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Rdp.json>
 
 Each CommandArg is of the form shown below, if multiple CommandArgs are present a random one is chosen for execution on each cycle.
 
 - `targetIp`|`credkey`  The targetIP is the IP to use for the RDP connection
-- The `credKey` is only used to retrieve the password of the matching record in the credentials file.
+- The `credKey` is only used to retrieve the password of the matching record in the credentials file (or from the timeline-embedded credentials)
 - The username (if supplied) is  used instead of the logged-in user (can also provide 'domain' keyword in credentials)
 - The password is used if a password  prompt appears on RDP open
 
@@ -45,3 +44,18 @@ Each CommandArg is of the form shown below, if multiple CommandArgs are present 
   ]
 }
 ```
+
+Note that the credentials can also be embedded directly in the timeline using `HandlerArgs[Credentials]` instead of an external file, see the SSH documentation for more details.
+
+Enabling RDP on the target host can be tricky.  The domain admin is an easy choice for username/password. 
+
+If you wish to use some other user, then a simple approach is to add that user to the `Domain Admins` group on the domain controller.
+This has the requirement that the querying user be in the same domain as the target host.
+
+Also, the following powershell can be used to enable RDP connections on the target host:
+```
+Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -name fDenyTSConnections -value 0 -erroraction SilentlyContinue
+Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+New-NetFirewallRule -DisplayName "Allow RDP RPC" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 1-600,3389 -Profile Any
+```
+

--- a/docs/core/handlers/reboot.md
+++ b/docs/core/handlers/reboot.md
@@ -1,7 +1,6 @@
 # Reboot Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Reboot.json>
 
 This is the only configuration possible for reboots currently. A fast loop configuration is probably not recommended, but once a day or similar is reasonable.
 

--- a/docs/core/handlers/sftp.md
+++ b/docs/core/handlers/sftp.md
@@ -1,7 +1,6 @@
 # Secure File Transfer Protocol (sFTP) Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Sftp.json>
 
 Each CommandArg is of the formation shown below, if multiple CommandArgs are present a random one is chosen for execution on each cycle.
 
@@ -50,3 +49,5 @@ Supported commands:
   ]
 }
 ```
+
+Note that the credentials can also be embedded directly in the timeline using `HandlerArgs[Credentials]` instead of using an external file, see the SSH documentation for more details.

--- a/docs/core/handlers/sharepoint_helper.md
+++ b/docs/core/handlers/sharepoint_helper.md
@@ -1,13 +1,14 @@
 # Sharepoint Helper Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/BrowserChromeSharepoint.json>
 
 The 'sharepoint' command for a browser handler allows download/deletion/upload from a sharepoint site.  
 
 The handlerArgs for the sharepoint command are:
     
 - "sharepoint-credentials-file": `json credentials file path`,  required, credentials file, see SSh.json sample handler for format
+- "sharepoint-credentials": embedded credentials instead of an external file, see documentation below.
 - "sharepoint-deletion-probability": <0-100 integer>, default  0
 - "sharepoint-upload-probability": <0-100 integer>, default 0
 - "sharepoint-download-probability": <0-100 integer>, default 0, sum of download+deletion+upload <= 100, download directory is browser download directory
@@ -64,3 +65,61 @@ A handler can only browse a single share point site. The username, password spec
   ]
 }
 ```
+
+Instead of using an external credentials file specified by the `HandlerArgs[sharepoint-credentials-file]` key, the credentials can be placed directly in the timeline using the `HandlerArgs[sharepoint-credentials]` key as shown below:
+
+```json
+{
+  "Status": "Run",
+  "TimeLineHandlers": [
+    {
+      "HandlerType": "BrowserChrome",
+      "HandlerArgs": {
+        "isheadless": "false",
+        "blockimages": "true",
+        "blockstyles": "true",
+        "blockflash": "true",
+        "blockscripts": "true",
+        "stickiness": 75,
+        "stickiness-depth-min": 5,
+        "stickiness-depth-max": 10000,
+        "incognito": "true",
+        "sharepoint-credentials": {
+          "Version": "1.0",
+          "Data": {
+            "credkey1": {"username":"user1","password":"pw1base64"},
+            "credkey2": {"username":"user2","password":"pw2base64"},
+              ....
+             "credkeyN": {"username":"userN","password":"pwNbase64"},
+          }
+        },
+        "sharepoint-deletion-probability": 15,
+        "sharepoint-upload-probability": 35,
+        "sharepoint-download-probability": 35,
+        "sharepoint-version": "2013",
+        "sharepoint-upload-directory": "C:\\ghosts_data\\uploads"
+
+      },
+      "Initial": "about:blank",
+      "UtcTimeOn": "00:00:00",
+      "UtcTimeOff": "24:00:00",
+      "Loop": "True",
+      "TimeLineEvents": [
+        {
+          "Command": "sharepoint",
+          "CommandArgs": [
+            "site:http://portal.sitea.com",
+            "credentialKey:credkey1"
+          ],
+          "DelayAfter": 60000,
+          "DelayBefore": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+Placing the credentials directly in the timeline is a better approach if the GhostsApi server is used to update the timeline as this makes the timeline self-contained.
+
+

--- a/docs/core/handlers/ssh.md
+++ b/docs/core/handlers/ssh.md
@@ -1,7 +1,6 @@
 # Secure Shell (SSH) Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Ssh.json>
 
 The credentials JSON file expected by this handler has the following format.
 
@@ -16,6 +15,8 @@ The credentials JSON file expected by this handler has the following format.
           }
 }
 ```
+
+
 
 The Version slot string is unused at the moment but is there in case this implementation is extended in the future. The credkey is simply some unique string that identifies the credential. The password is assumed to be UTF8 that is base64 encoded. See src\Ghosts.Client\Infrastructure\SshSupport.cs for a list [`reservedword`] supported in Ssh commands
 
@@ -51,3 +52,49 @@ The Version slot string is unused at the moment but is there in case this implem
   ]
 }
 ```
+
+Instead of using an external credentials file specified by the `HandlerArgs[CredentialsFile]` key, the credentials can be placed directly in the timeline using the `HandlerArgs[Credentials]` key as shown below:
+
+```json
+{
+  "Status": "Run",
+  "TimeLineHandlers": [
+    {
+      "HandlerType": "Ssh",
+      "HandlerArgs": {
+        "CommandTimeout": 1000, //max time to wait for new input from an SSH command execution
+        "TimeBetweenCommandsMax": 5000, //max,min between individual SSH commands
+        "TimeBetweenCommandsMin": 1000,
+        "ValidExts": "txt;doc;png;jpeg", //used by [randomextension] reserved word, choose random extension from this list
+        "Credentials": {
+           "Version": "1.0",
+           "Data": {
+             "credkey1": {"username":"user1","password":"pw1base64"},
+             "credkey2": {"username":"user2","password":"pw2base64"},
+              ....
+             "credkeyN": {"username":"userN","password":"pwNbase64"},
+          }
+        },
+        "delay-jitter": 0 //optional, default =0, range 0 to 50, if specified, DelayAfter varied by delay-%jitter*delay to delay+%jitter*delay
+      },
+      "Initial": "",
+      "UtcTimeOn": "00:00:00",
+      "UtcTimeOff": "24:00:00",
+      "Loop": "True",
+      "TimeLineEvents": [
+        {
+          "Command": "random",
+          "CommandArgs": [
+            "<an IP>|<unique_key_from_credentials>|ls -lah;ls -ltrh;help;pwd;date;time;uptime;uname -a;df -h;cd ~;cd [remotedirectory];touch [randomname].[randomextension];mkdir [randomname]"  //<serverIP>|<credKey|<commmandList>
+          ],
+          "DelayAfter": 20000,
+          "DelayBefore": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+Placing the credentials directly in the timeline is a better approach if the GhostsApi server is used to update the timeline as this makes the timeline self-contained.
+

--- a/docs/core/handlers/watcher.md
+++ b/docs/core/handlers/watcher.md
@@ -1,7 +1,7 @@
 # File Watcher Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Watcher.json>
 
 The 'folder' command for Watcher is intended to monitor diskspace in a target folder. The CommandArgs are in key:value pairs:
 

--- a/docs/core/handlers/wmi.md
+++ b/docs/core/handlers/wmi.md
@@ -1,9 +1,8 @@
 # Windows Management Instrumentation (WMI) Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Wmi.json>
 
-Each CommandArg is of the formation shown below, if multiple CommandArgs are present a random one is chosen for execution on each cycle.
+Each CommandArg is of the form shown below. If multiple CommandArgs are present then a random one is chosen for execution on each cycle.
 Credential handling is done in the same manner as the SSH handler, see that sample timeline for documentation.
 After the `cred_key` is a ';' delimited list of WMI commands that are executed in sequence during a cycle.
 
@@ -18,9 +17,17 @@ Supported commands:
 - GetProcessList
 
 The credentials file uses the same format as SFTP/SSH, but requires a 'domain' keyword in addition to 'username', 'password'
-For this to work, the target host needs to be configured to allow WMI
-The domain admin is the best choice for username/password
-The trusted hosts of the VM running GHOSTS must be set to include the IPs of any of the hosts being interrogated by WMI
+For this to work, the target host needs to be configured to allow WMI. The domain admin is the best choice for username/password.
+If you wish to use some other user, then a simple approach is to add that user to the `Domain Admins` group on the domain controller.
+This has the requirement that the querying user be in the same domain as the target host.
+
+Also, on the target host for WMI, modify the firewall with:
+```
+netsh advfirewall firewall set rule group="windows management instrumentation (wmi)" new enable=yes
+netsh advfirewall firewall set rule group="RemoteAdministration" new enable=yes
+```
+
+You may also need to set trusted hosts of the VM running GHOSTS to include the IPs of any of the hosts being interrogated by WMI.
 
 You can print the Trusted hosts if the current host by executing in Powershell:
 
@@ -62,3 +69,5 @@ You can set Trusted Hosts to a wild card (trust all hosts) by executing in Power
   ]
 }
 ```
+
+Note that the credentials can also be embedded directly in the timeline using `HandlerArgs[Credentials]` instead of using an external file, see the SSH documentation for more details.

--- a/docs/core/handlers/word.md
+++ b/docs/core/handlers/word.md
@@ -1,7 +1,7 @@
 # Word Configuration
 
-???+ info "Sample Configuration"
-    The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client/Sample%20Timelines/clicks>
+
+The sample configuration below is also available in the [GHOSTS GitHub repository](<https://github.com/cmu-sei/GHOSTS/blob/master/src/Ghosts.Client.Windows/Sample%20Timelines/Word.json>
 
 ```json
 {

--- a/src/Ghosts.Client.Windows/Sample Timelines/Database.json
+++ b/src/Ghosts.Client.Windows/Sample Timelines/Database.json
@@ -15,9 +15,9 @@
         "DatabaseTargets": {
            "Version": "1.0",
              "Data": {
-               "164.236.110.15_s1-svr-db15": {
-                  "Username": "meredith.palmer",
-                  "Password": "UDQ1NXcwcmQh",
+               "akeyvalue1": {
+                  "Username": "auser",
+                  "Password": "aBase64encodePassword",
                   "Databases": [
                     {
                       "Name": "AcmeInc",
@@ -74,7 +74,7 @@
         {
           "Command": "random",
           "CommandArgs": [
-             "164.236.110.15|164.236.110.15_s1-svr-db15",
+             "xx.xx.xx.xx|akeyvalue1",
           ],
           "DelayAfter": 20000,
           "DelayBefore": 0


### PR DESCRIPTION

This is a documentation update only.  

Updated handler docs like sftp, wmi, rdp, ssh, blog_helper, sharepoint_helper that support embedding credentials directly in the timeline instead of an external file. This was added a while back but never documented.

Fixed broken links to sample timelines in all handler docs.
