### PR TITLE
fix(client-windows): read reply sender address via Redemption to avoid Outlook security prompt

### DIFF
--- a/src/Ghosts.Client.Windows/Handlers/Outlook.cs
+++ b/src/Ghosts.Client.Windows/Handlers/Outlook.cs
@@ -312,6 +312,9 @@ public class Outlook : BaseHandler
             {
                 if (!folderItem.UnRead) continue;
 
+                // read the sender via Redemption to avoid Outlook's security prompt
+                var safeFolderItem = new SafeMailItem { Item = folderItem };
+
                 var emailReply = new EmailReplyManager();
                         
                 var replyMail = folderItem.Reply();
@@ -321,7 +324,7 @@ public class Outlook : BaseHandler
                     quoted.WriteLine(emailReply.Reply);
                     quoted.WriteLine("");
                     quoted.WriteLine("");
-                    quoted.WriteLine($"On {folderItem.SentOn:f}, {folderItem.SenderEmailAddress} wrote:");
+                    quoted.WriteLine($"On {folderItem.SentOn:f}, {safeFolderItem.SenderEmailAddress} wrote:");
                     using (var reader = new StringReader(folderItem.Body))
                     {
                         string line;
@@ -342,7 +345,7 @@ public class Outlook : BaseHandler
                     Item = replyMail
                 };
 
-                var r = rdoMail.Recipients.AddEx(folderItem.SenderEmailAddress);
+                var r = rdoMail.Recipients.AddEx(safeFolderItem.SenderEmailAddress);
                 r.Resolve();
                 rdoMail.Recipients.ResolveAll();
                 rdoMail.Send();

--- a/src/Ghosts.Client.Windows/Handlers/Outlookv2.cs
+++ b/src/Ghosts.Client.Windows/Handlers/Outlookv2.cs
@@ -987,7 +987,9 @@ public class Outlookv2 : BaseHandler
                     folderItem = item as MailItem;
                     if (folderItem == null) continue;
                     bool reject = false;
-                    var targetEmail = folderItem.SenderEmailAddress.ToLower();
+                    // read the sender via Redemption to avoid Outlook's security prompt
+                    var safeFolderItem = new SafeMailItem { Item = folderItem };
+                    var targetEmail = safeFolderItem.SenderEmailAddress.ToLower();
                     if (EmailNoReply != null && EmailNoReply.Length > 0)
                     {
                         foreach (string target in EmailNoReply)
@@ -1014,7 +1016,7 @@ public class Outlookv2 : BaseHandler
                         quoted.WriteLine(emailReply.Reply);
                         quoted.WriteLine("");
                         quoted.WriteLine("");
-                        quoted.WriteLine($"On {folderItem.SentOn:f}, {folderItem.SenderEmailAddress} wrote:");
+                        quoted.WriteLine($"On {folderItem.SentOn:f}, {safeFolderItem.SenderEmailAddress} wrote:");
                         using (var reader = new StringReader(folderItem.Body))
                         {
                             string line;
@@ -1035,7 +1037,7 @@ public class Outlookv2 : BaseHandler
                         Item = replyMail
                     };
 
-                    var r = rdoMail.Recipients.AddEx(folderItem.SenderEmailAddress);
+                    var r = rdoMail.Recipients.AddEx(safeFolderItem.SenderEmailAddress);
                     r.Resolve();
                     rdoMail.Recipients.ResolveAll();
                     rdoMail.Send();


### PR DESCRIPTION
Fixes #667.

## Problem

The Windows Outlook **reply** handlers read the incoming message's sender address directly off the Outlook Interop `MailItem` (`folderItem.SenderEmailAddress`). That property is guarded by Outlook's Object Model Guard, so on hosts where Outlook cannot confirm an up-to-date, registered antivirus it raises the "A program is trying to access email address information stored in Outlook" prompt and blocks the automated timeline until a user clicks **Allow**.

Every other Outlook action already routes through Redemption's `SafeMailItem`, which bypasses the guard; only the reply path still used raw Interop for the sender read.

## Change

Wrap the inbox item in a Redemption `SafeMailItem` and read `SenderEmailAddress` from it, in both reply handlers:

- `src/Ghosts.Client.Windows/Handlers/Outlookv2.cs` (`ReplyViaOutlook`)
- `src/Ghosts.Client.Windows/Handlers/Outlook.cs` (`ReplyViaOutlook`)

`using Redemption;` and `SafeMailItem` are already present in both files (used on the send path), so no new imports or references. The change is intended to be **behavior-preserving**: `SafeMailItem.SenderEmailAddress` returns the same underlying MAPI property value (SMTP for internet senders, EX/X500 for Exchange senders) as `MailItem.SenderEmailAddress` — it just doesn't trip the guard. Non-guarded properties (`SentOn`, `Subject`, `Body`, `Reply()`, `UnRead`) are left on the Interop object.

## Testing

**Not runtime-tested.** This is a code-level change verified by inspection only — I don't have a Windows/Outlook environment to build and exercise the .NET Framework client. The reasoning is that reading the same property through `SafeMailItem` (already used for sending in both handlers) yields the same value without invoking the Object Model Guard.

A maintainer with a Windows + Outlook + Redemption setup should confirm that, on a host where the prompt currently appears, a reply cycle (non-zero `reply-probability`, mail in the inbox) completes without the "access email address information" dialog and the reply still sends and resolves recipients correctly.