### PR TITLE
fix(client-windows): package msedgedriver and make the Edge handler actually use it

### DIFF
--- a/src/Ghosts.Client.Windows/Ghosts.Client.csproj
+++ b/src/Ghosts.Client.Windows/Ghosts.Client.csproj
@@ -512,6 +512,9 @@
     <PackageReference Include="Selenium.WebDriver.GeckoDriver">
       <Version>0.34.0</Version>
     </PackageReference>
+    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver">
+      <Version>149.0.4022.98</Version>
+    </PackageReference>
     <PackageReference Include="SharpZipLib">
       <Version>1.4.2</Version>
     </PackageReference>

--- a/src/Ghosts.Client.Windows/Handlers/BrowserEdge.cs
+++ b/src/Ghosts.Client.Windows/Handlers/BrowserEdge.cs
@@ -294,7 +294,7 @@ namespace Ghosts.Client.Handlers
 
             var service = EdgeDriverService.CreateDefaultService(AppDomain.CurrentDomain.BaseDirectory);
             service.HideCommandPromptWindow = true;
-            var driver = new EdgeDriver(options);
+            var driver = new EdgeDriver(service, options);
             driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
             return driver;
         }

--- a/src/Ghosts.Client.Windows/Infrastructure/ProcessManager.cs
+++ b/src/Ghosts.Client.Windows/Infrastructure/ProcessManager.cs
@@ -141,8 +141,8 @@ public static class ProcessManager
         public static string Chrome => "chrome";
         public static string ChromeDriver => "chromedriver";
 
-        public static string MSEdge => "Microsoft Edge";
-        public static string MSEdgeDriver => "Microsoft Edge WebDriver (32 bit)";
+        public static string MSEdge => "msedge";
+        public static string MSEdgeDriver => "msedgedriver";
 
         public static string Command => "cmd";
         public static string PowerShell => "powershell";


### PR DESCRIPTION
## Problem

The Windows client has a `BrowserEdge` handler, but Edge cannot actually be driven. Three things are wrong, and all three have to be fixed for the handler to work:

1. **No driver is packaged.** `chromedriver.exe` and `geckodriver.exe` reach the output directory because `Selenium.WebDriver.ChromeDriver` and `Selenium.WebDriver.GeckoDriver` each carry a build target that copies the driver into `$(TargetDir)`. There is no equivalent for Edge, so `msedgedriver.exe` is never produced by the build.

2. **`GetEdgeDriver` throws away the service it just built.** `Handlers/BrowserEdge.cs` builds an `EdgeDriverService` rooted at the application base directory and sets `HideCommandPromptWindow` on it, then calls `new EdgeDriver(options)` — which discards that service and constructs its own. Both the base-directory pin and the hidden console window are inert. `BrowserChrome` does this correctly (`new ChromeDriver(service, options)`).

   The practical consequence: the discarded service leaves `DriverServicePath` unset, so Selenium falls through to `DriverFinder`/Selenium Manager, which resolves the driver **by downloading it**. On a host with no outbound network access this fails even when `msedgedriver.exe` is sitting next to `ghosts.exe`. (`Ghosts.Client.Universal`'s `BrowserFirefox` has a comment describing exactly this reasoning for pinning the service.)

3. **The Edge process names are file descriptions, not process names.** `ProcessNames.MSEdge` is `"Microsoft Edge"` and `ProcessNames.MSEdgeDriver` is `"Microsoft Edge WebDriver (32 bit)"`. Both are handed to `KillProcessAndChildrenByName`, which calls `Process.GetProcessesByName`, so neither ever matches and `BrowserEdge`'s cleanup silently reaps nothing. `msedge.exe` and `msedgedriver.exe` accumulate for the life of the client. Compare `Chrome => "chrome"` / `ChromeDriver => "chromedriver"`.

## Change

Three commits, one concern each, all confined to `Ghosts.Client.Windows`:

- **`build(client-windows)`** — add `Selenium.WebDriver.MSEdgeDriver` to `Ghosts.Client.csproj`. It is the same shape as the ChromeDriver/GeckoDriver packages already in use (its `CopyMsEdgeDriverToBin` target runs `BeforeTargets="AfterBuild"` and copies `driver/win32/msedgedriver.exe` into `$(TargetDir)`). Pinned explicitly, as the other two are.

  `WebDriverPlatform` is deliberately left unset. All three driver packages share that property and resolve it to `win32` on Windows; the ChromeDriver package ships no `win64` directory, so forcing it would break the existing chromedriver copy.

- **`fix(client-windows)`** — pass the already-constructed service: `new EdgeDriver(service, options)`. Selenium then loads the driver from the base directory and never invokes Selenium Manager. This also makes the existing `HideCommandPromptWindow = true` take effect.

- **`fix(client-windows)`** — `MSEdge => "msedge"`, `MSEdgeDriver => "msedgedriver"`.

Nothing outside the Edge path is touched, and no adjacent code is refactored.

## Testing

**Not runtime-tested.** I don't have a Windows environment to build and exercise the .NET Framework client, so this is verified by inspection plus direct inspection of the NuGet package, not by running GHOSTS.

What I did confirm:

- `Selenium.WebDriver.MSEdgeDriver` `149.0.4022.98` contains `driver/win32/msedgedriver.exe` (PE32, i386 — consistent with the `(32 bit)` name the old `ProcessNames` string used), `driver/win64/msedgedriver.exe`, and `build/Selenium.WebDriver.MSEdgeDriver.targets`.
- That targets file defines `CopyMsEdgeDriverToBin` with `BeforeTargets="AfterBuild"` and `Condition="'$(PublishMsEdgeDriver)' == 'false'"`, where `PublishMsEdgeDriver` defaults to `false` — i.e. a plain `msbuild` build copies the driver to `$(TargetDir)` without any extra property. `DefinePropertiesMSEdgeDriver.targets` resolves `WebDriverPlatform` to `win32` when `$(OS) == 'Windows_NT'`.

A maintainer with a Windows build should confirm:

- [ ] `msedgedriver.exe` appears in `bin\x86\Release\` and `bin\x64\Release\`, and `chromedriver.exe` / `geckodriver.exe` are still present (regression check on the shared `WebDriverPlatform` property).
- [ ] A timeline with `"HandlerType": "BrowserEdge"` starts Edge, with no console window flash.
- [ ] With outbound network blocked and `msedgedriver.exe` next to `ghosts.exe`, Edge still starts and `selenium-manager.exe` never spawns.
- [ ] After the handler finishes, no orphaned `msedge.exe` / `msedgedriver.exe` remain.

## Note

`Ghosts.Client.Universal`'s `BrowserEdge` has the same "no service" shape (`new EdgeDriver(options)`) and its csproj carries no Edge driver package either. I've left it alone to keep this PR to one concern, but it likely needs the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
