### PR TITLE
Update machine fields on client check-in

### DIFF
--- a/src/Ghosts.Api.Tests/MachineServiceTests.cs
+++ b/src/Ghosts.Api.Tests/MachineServiceTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Ghosts.Api.Infrastructure.Models;
+using Xunit;
+
+namespace Ghosts.Api.Tests;
+
+public class MachineTests
+{
+    [Fact]
+    public void UpdateFromCheckIn_UpdatesUsernameAndStatus()
+    {
+        var lastReported = DateTime.UtcNow.AddHours(-1);
+        var machine = new Machine
+        {
+            Name = "workstation-01",
+            FQDN = "workstation-01.example.test",
+            Domain = "example.test",
+            Host = "workstation-01",
+            ResolvedHost = "workstation-01.example.test",
+            HostIp = "192.0.2.10",
+            CurrentUsername = "user-a",
+            ClientVersion = "9.0.0",
+            Status = StatusType.Active,
+            StatusUp = Machine.UpDownStatus.Down,
+            LastReportedUtc = lastReported
+        };
+
+        machine.UpdateFromCheckIn(new Machine
+        {
+            Name = "workstation-01",
+            FQDN = "workstation-01.example.test",
+            Domain = "example.test",
+            Host = "workstation-01",
+            ResolvedHost = "workstation-01.example.test",
+            HostIp = "192.0.2.10",
+            IPAddress = "::ffff:192.0.2.10",
+            CurrentUsername = "user-b",
+            ClientVersion = "9.3.0",
+            StatusUp = Machine.UpDownStatus.Up
+        });
+
+        Assert.Equal("user-b", machine.CurrentUsername);
+        Assert.Equal("9.3.0", machine.ClientVersion);
+        Assert.Equal(Machine.UpDownStatus.Up, machine.StatusUp);
+        Assert.Equal("::ffff:192.0.2.10", machine.IPAddress);
+        Assert.True(machine.LastReportedUtc > lastReported);
+    }
+}

--- a/src/Ghosts.Api/Infrastructure/Models/Machine.cs
+++ b/src/Ghosts.Api/Infrastructure/Models/Machine.cs
@@ -101,6 +101,21 @@ namespace Ghosts.Api.Infrastructure.Models
                    !string.IsNullOrEmpty(CurrentUsername);
         }
 
+        public void UpdateFromCheckIn(Machine checkIn)
+        {
+            Name = checkIn.Name;
+            FQDN = checkIn.FQDN;
+            Domain = checkIn.Domain;
+            Host = checkIn.Host;
+            ResolvedHost = checkIn.ResolvedHost;
+            HostIp = checkIn.HostIp;
+            IPAddress = checkIn.IPAddress;
+            CurrentUsername = checkIn.CurrentUsername;
+            ClientVersion = checkIn.ClientVersion;
+            StatusUp = checkIn.StatusUp;
+            LastReportedUtc = DateTime.UtcNow;
+        }
+
         [NotMapped]
         public bool HadId { get; set; }
 

--- a/src/Ghosts.Api/Infrastructure/Services/MachineService.cs
+++ b/src/Ghosts.Api/Infrastructure/Services/MachineService.cs
@@ -86,13 +86,9 @@ namespace Ghosts.Api.Infrastructure.Services
             {
                 machineResponse.Machine = m;
 
-                // if new version, update that info
-                if (!m.ClientVersion.Equals(httpHeadersMachine.ClientVersion))
-                {
-                    m.ClientVersion = httpHeadersMachine.ClientVersion;
-                    _context.Entry(m).State = EntityState.Modified;
-                    await _context.SaveChangesAsync(ct);
-                }
+                m.UpdateFromCheckIn(httpHeadersMachine);
+                _context.Entry(m).State = EntityState.Modified;
+                await _context.SaveChangesAsync(ct);
             }
 
             return machineResponse;


### PR DESCRIPTION
Fixes #671 

## Summary

Fixes existing machine check-ins so the API persists the latest client-reported machine fields, including `CurrentUsername`.

Previously, `MachineService.FindOrCreate` only updated `ClientVersion` for existing machine records. This meant a workstation checking in under a different user could still show the old `CurrentUsername` in `/api/machines`.

  ## Changes

  - Added `Machine.UpdateFromCheckIn(...)`.
  - Updated existing-machine check-in handling to persist current check-in fields.
  - Added a regression test with generic example host/user data.

  ## Testing

  ```bash
  dotnet test src/Ghosts.Api.Tests/Ghosts.Api.Tests.csproj
  dotnet build GHOSTS.sln
  ```
  AI-assisted: Used Codex to identify the check-in update path and draft the focused fix/test.