### PR TITLE
Preserve timeline UUIDs from external orchestration systems

### DIFF
--- a/src/Ghosts.Api/Infrastructure/Services/MachineUpdateService.cs
+++ b/src/Ghosts.Api/Infrastructure/Services/MachineUpdateService.cs
@@ -117,7 +117,8 @@ public class MachineUpdateService(
         if (machineUpdate != null)
             return machineUpdate;
 
-        model.Update.Id = Guid.NewGuid();
+        if (model.Update.Id == Guid.Empty)
+            model.Update.Id = Guid.NewGuid();
 
         context.MachineUpdates.Add(model);
         await context.SaveChangesAsync(ct);


### PR DESCRIPTION
Fix timeline delivery reconciliation by preserving caller-supplied timeline UUIDs when creating machine updates. Generate a UUID only when the incoming timeline does not provide one.

Closes #693 