### PR TITLE
Honor configured timeline location in Universal client

### DIFF
--- a/src/Ghosts.Domain/Code/ApplicationDetails.cs
+++ b/src/Ghosts.Domain/Code/ApplicationDetails.cs
@@ -120,6 +120,11 @@ namespace Ghosts.Domain.Code
             public static string Timeline
             {
                 get {
+                    var configuredPath = ClientConfigurationLoader.Config?.Timeline?.Location;
+                    if (!string.IsNullOrWhiteSpace(configuredPath) &&
+                        !configuredPath.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                        return GetPath(configuredPath);
+
                     var baseName = Clean(InstallPath + "timeline");
                     string[] extensions = {".yaml", ".yml", ".json"};
                     foreach (var ext in extensions) {


### PR DESCRIPTION
The Universal client now resolves local timelines using `Timeline.Location` from `application.json`. Legacy extension-based discovery remains as a fallback when no location is configured, and URL timeline behavior is unchanged. 

This prevents Linux deployments from silently preferring `timeline.yaml` over the configured `timeline.json`.

Fixes #705 