### PR TITLE
Simplified file attachment code for OutlookHelper,SocialHelper

### DIFF
--- a/src/Ghosts.Client.Universal/Handlers/OutlookHelper.cs
+++ b/src/Ghosts.Client.Universal/Handlers/OutlookHelper.cs
@@ -191,54 +191,6 @@ public abstract class OutlookHelper : BrowserHelper
         return OsName.Contains("Windows");
     }
 
-    public static void AttachFileWindows(string filename)
-    {
-        //IntPtr winHandle = Winuser.FindWindow(null, AttachmentWindowTitle);
-        //if (winHandle == IntPtr.Zero)
-        //{
-        //    Log.Trace($"WebOutlook:: Unable to find '{AttachmentWindowTitle}' window to upload file attachment.");
-        //    return;
-        //}
-        //Winuser.SetForegroundWindow(winHandle);
-        //string s;
-        //if (Driver is OpenQA.Selenium.Firefox.FirefoxDriver)
-        //{
-        //    s = filename + "{TAB}{TAB}{ENTER}";
-        //}
-        //else
-        //{
-        //    s = filename + "{ENTER}";
-        //}
-
-        //System.Windows.Forms.SendKeys.SendWait(s);
-        //Thread.Sleep(200);
-        //winHandle = Winuser.FindWindow(null, AttachmentWindowTitle);
-        //if (winHandle == IntPtr.Zero)
-        //{
-        //    return;
-        //}
-        // the window is still open. Grr. try closing it.
-        //Winuser.SetForegroundWindow(winHandle);
-        //System.Windows.Forms.SendKeys.SendWait("%{F4}");
-    }
-
-
-    public void AttachFileLinux(string filename)
-    {
-        var status = linuxHelper.AttachFileUsingThread("WebOutlook", filename, AttachmentWindowTitle, 30, 2);
-        if (!status)
-        {
-            //force a restart
-            errorCount = errorThreshold + 1;
-        }
-    }
-
-    public void AttachFile(string filename)
-    {
-        if (isWindowsOs()) AttachFileWindows(filename);
-        else AttachFileLinux(filename);
-    }
-
 
     public static OutlookHelper MakeHelper(BaseBrowserHandler callingHandler, IWebDriver callingDriver,
         TimelineHandler handler, Logger tlog, CancellationToken atoken)
@@ -674,10 +626,8 @@ public abstract class OutlookHelper : BrowserHelper
                                 insertElement = Driver.FindElement(By.XPath(InsertAttachmentXpath));
                                 if (insertElement != null)
                                 {
-                                    BrowserHelperSupport.ElementClick(Driver, insertElement);
+                                    insertElement.SendKeys(FileToAttach);
                                     if (token.WaitHandle.WaitOne(500)) token.ThrowIfCancellationRequested();
-                                    //filechoice window is open
-                                    AttachFile(FileToAttach);
                                 }
                             }
                         }
@@ -686,10 +636,8 @@ public abstract class OutlookHelper : BrowserHelper
                             var insertAttachmentElement = Driver.FindElement(By.XPath(InsertAttachmentXpath));
                             if (insertAttachmentElement != null)
                             {
-                                BrowserHelperSupport.ElementClick(Driver, insertAttachmentElement);
+                                insertAttachmentElement.SendKeys(FileToAttach);
                                 if (token.WaitHandle.WaitOne(500)) token.ThrowIfCancellationRequested();
-                                //filechoice window is open
-                                AttachFile(FileToAttach);
                             }
                         }
                     }

--- a/src/Ghosts.Client.Universal/Handlers/SocialHelper.cs
+++ b/src/Ghosts.Client.Universal/Handlers/SocialHelper.cs
@@ -165,10 +165,7 @@ public class SocialHelperV1 : SocialHelper
                         "//label[text()='Share what you are thinking here...']//following-sibling::input[@type='file']"));
                     if (targetElement != null)
                     {
-                        BrowserHelperSupport.ElementClick(Driver, targetElement);
-                        if (token.WaitHandle.WaitOne(500)) token.ThrowIfCancellationRequested();
-                        //filechoice window is open
-                        AttachFile(imageFile);
+                        targetElement.SendKeys(imageFile);
                         if (token.WaitHandle.WaitOne(500)) token.ThrowIfCancellationRequested();
                     }
                 }
@@ -321,29 +318,6 @@ public abstract partial class SocialHelper : BrowserHelper
 
         return true;
     }
-
-
-    public static void AttachFileWindows(string filename)
-    {
-        // not supported
-    }
-
-    public void AttachFileLinux(string filename)
-    {
-        var status = linuxHelper.AttachFileUsingThread("Social", filename, AttachmentWindowTitle, 30, 2);
-        if (!status)
-        {
-            //force a restart
-            errorCount = errorThreshold + 1;
-        }
-    }
-
-    public void AttachFile(string filename)
-    {
-        if (isWindowsOs()) AttachFileWindows(filename);
-        else AttachFileLinux(filename);
-    }
-
 
     public string GetUploadFile()
     {

--- a/src/Ghosts.Client.Universal/Infrastructure/LinuxSupport.cs
+++ b/src/Ghosts.Client.Universal/Infrastructure/LinuxSupport.cs
@@ -145,46 +145,5 @@ namespace Ghosts.Client.Universal.Infrastructure
             Log = aLog;
         }
 
-        public bool AttachFileUsingThread(string id, string filename, string windowTitle, int timeoutSeconds,
-            int retries)
-        {
-            // Use a thread in case the xdotool execution hangs
-
-            runner ??= new BashExecute(Log);
-            runner.id = id;
-            runner.windowTitle = windowTitle;
-            runner.filename = filename;
-            var count = 0;
-            while (count < retries + 1)
-            {
-                Thread t = new Thread(new ThreadStart(runner.AttachFile));
-                t.Start();
-                var totalTime = 0;
-                while (totalTime < timeoutSeconds)
-                {
-                    Thread.Sleep(10000);
-                    if (!t.IsAlive) break;
-                    totalTime += 10;
-                }
-
-                if (t.IsAlive)
-                {
-                    t.Join();
-                    Thread.Sleep(5000);
-                    retries += 1;
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            if (runner.GetNeedRestart())
-            {
-                return false;
-            }
-
-            return (count < retries + 1);
-        }
     }
 }

--- a/src/Ghosts.Client.Windows/Handlers/OutlookHelper.cs
+++ b/src/Ghosts.Client.Windows/Handlers/OutlookHelper.cs
@@ -203,54 +203,6 @@ namespace Ghosts.Client.Handlers
             return OsName.Contains("Windows");
         }
 
-        public void AttachFileWindows(string filename)
-        {
-            IntPtr winHandle = Winuser.FindWindow(null, AttachmentWindowTitle);
-            if (winHandle == IntPtr.Zero)
-            {
-                Log.Trace($"WebOutlook:: Unable to find '{AttachmentWindowTitle}' window to upload file attachment.");
-                return;
-            }
-            Winuser.SetForegroundWindow(winHandle);
-            string s;
-            if (Driver is OpenQA.Selenium.Firefox.FirefoxDriver)
-            {
-                s = filename + "{TAB}{TAB}{ENTER}";
-            }
-            else
-            {
-                s = filename + "{ENTER}";
-            }
-
-            System.Windows.Forms.SendKeys.SendWait(s);
-            Thread.Sleep(200);
-            winHandle = Winuser.FindWindow(null, AttachmentWindowTitle);
-            if (winHandle == IntPtr.Zero)
-            {
-                return;
-            }
-            // the window is still open. Grr. try closing it.
-            Winuser.SetForegroundWindow(winHandle);
-            System.Windows.Forms.SendKeys.SendWait("%{F4}");
-        }
-
-        public void AttachFileLinux(string filename)
-        {
-            string cmd = $"xdotool search -name '{AttachmentWindowTitle}' windowfocus type '{filename}' ";
-            ExecuteBashCommand(cmd);
-            Thread.Sleep(500);
-            cmd = $"xdotool search -name '{AttachmentWindowTitle}' windowfocus key KP_Enter";
-            ExecuteBashCommand(cmd);
-            Thread.Sleep(300);
-            return;
-        }
-
-        public void AttachFile(string filename)
-        {
-            if (isWindowsOs()) AttachFileWindows(filename);
-            else AttachFileLinux(filename);
-        }
-
 
         public static OutlookHelper MakeHelper(BaseBrowserHandler callingHandler, IWebDriver callingDriver, TimelineHandler handler, Logger tlog)
         {
@@ -630,10 +582,8 @@ namespace Ghosts.Client.Handlers
                                     insertElement = Driver.FindElement(By.XPath(InsertAttachmentXpath));
                                     if (insertElement != null)
                                     {
-                                        BrowserHelperSupport.ElementClick(Driver, insertElement);
+                                        insertElement.SendKeys(FileToAttach);
                                         Thread.Sleep(500);
-                                        //filechoice window is open
-                                        AttachFile(FileToAttach);
                                     }
                                 }
                             }
@@ -642,10 +592,8 @@ namespace Ghosts.Client.Handlers
                                 var insertAttachmentElement = Driver.FindElement(By.XPath(InsertAttachmentXpath));
                                 if (insertAttachmentElement != null)
                                 {
-                                    BrowserHelperSupport.ElementClick(Driver, insertAttachmentElement);
+                                    insertAttachmentElement.SendKeys(FileToAttach);
                                     Thread.Sleep(500);
-                                    //filechoice window is open
-                                    AttachFile(FileToAttach);
                                 }
                             }
                         }

--- a/src/Ghosts.Client.Windows/Handlers/SocialHelper.cs
+++ b/src/Ghosts.Client.Windows/Handlers/SocialHelper.cs
@@ -153,10 +153,7 @@ namespace Ghosts.Client.Handlers
                         targetElement =  Driver.FindElement(By.XPath("//label[text()='Share what you are thinking here...']//following-sibling::input[@type='file']"));
                         if (targetElement != null)
                         {
-                            BrowserHelperSupport.ElementClick(Driver, targetElement);
-                            Thread.Sleep(500);
-                            //filechoice window is open
-                            AttachFile(imageFile );
+                            targetElement.SendKeys(imageFile);
                             Thread.Sleep(500);
                         }
                     }


### PR DESCRIPTION
This greatly simplifies the file attachment code OutlookHelper, Social Helper in Ghosts.Client.Universal, Ghosts.Client.Windows.

This affects the file attachment done by the WebOutlookEmail and WebSocial handlers.

The original code triggered the native OS file picker and then jumped through hoops to submit the file path through that mechanism when the file path should have simply been passed by Selenium directly to the input element that required the file path.

